### PR TITLE
Add TOSCA 1.3 compliant parser

### DIFF
--- a/src/opera/error.py
+++ b/src/opera/error.py
@@ -1,0 +1,10 @@
+class OperaError(Exception):
+    """ Base opera exception for catch-all-opera-errors constructs. """
+
+
+class ParseError(OperaError):
+    """ Exception that is raised on invalid TOSCA document. """
+
+    def __init__(self, msg, loc):
+        super().__init__(msg)
+        self.loc = loc

--- a/src/opera/parser/tosca/base.py
+++ b/src/opera/parser/tosca/base.py
@@ -1,0 +1,37 @@
+from opera.error import ParseError
+
+
+class Base:
+    @classmethod
+    def parse(cls, yaml_node):
+        print("Parsing [{}] {}".format(cls.__name__, yaml_node.loc))
+        yaml_node = cls.normalize(yaml_node)
+        cls.validate(yaml_node)
+        return cls.build(yaml_node)
+
+    @classmethod
+    def normalize(cls, yaml_node):
+        return yaml_node
+
+    @classmethod
+    def validate(cls, _yaml_node):
+        pass
+
+    @classmethod
+    def build(cls, yaml_node):
+        return cls(yaml_node.value, yaml_node.loc)
+
+    @classmethod
+    def abort(cls, msg, loc=None):
+        raise ParseError("[{}] {}".format(cls.__name__, msg), loc)
+
+    def __init__(self, data, loc):
+        self.data = data
+        self.loc = loc
+
+    @property
+    def bare(self):
+        return self.data
+
+    def __str__(self):
+        return str(self.bare)

--- a/src/opera/parser/tosca/bool.py
+++ b/src/opera/parser/tosca/bool.py
@@ -1,0 +1,9 @@
+from .comparable import Comparable
+
+
+class Bool(Comparable):
+    @classmethod
+    def validate(cls, yaml_node):
+        super().validate(yaml_node)
+        if not isinstance(yaml_node.value, bool):
+            cls.abort("Expected boolean value.", yaml_node.loc)

--- a/src/opera/parser/tosca/comparable.py
+++ b/src/opera/parser/tosca/comparable.py
@@ -1,0 +1,9 @@
+from .base import Base
+
+
+class Comparable(Base):
+    def __eq__(self, other):
+        return self.data == other.data
+
+    def __hash__(self):
+        return hash(self.data)

--- a/src/opera/parser/tosca/entity.py
+++ b/src/opera/parser/tosca/entity.py
@@ -1,0 +1,106 @@
+from .base import Base
+from .map import Map
+from .reference import Reference
+from .string import String
+from .version import Version
+
+
+class Entity(Base):
+    ATTRS = {}  # This must be overridden in derived classes
+    REQUIRED = set()  # This can be overriden in derived classes
+
+    @classmethod
+    def validate(cls, yaml_node):
+        assert cls.ATTRS != {}
+        assert isinstance(cls.REQUIRED, set)
+
+        if not isinstance(yaml_node.value, dict):
+            cls.abort("Expected map.", yaml_node.loc)
+
+        data_keys = set()
+        for k in yaml_node.value:
+            if not isinstance(k.value, str):
+                cls.abort("Expected string", k.loc)
+            data_keys.add(k.value)
+
+        missing_keys = cls.REQUIRED - data_keys
+        if missing_keys:
+            cls.abort(
+                "Missing required fields: {}".format(", ".join(missing_keys)),
+                yaml_node.loc,
+            )
+
+        extra_keys = data_keys - cls.attrs().keys()
+        if extra_keys:
+            cls.abort(
+                "Invalid keys: {}".format(", ".join(extra_keys)),
+                yaml_node.loc,
+            )
+
+    @classmethod
+    def build(cls, yaml_node):
+        classes = cls.attrs()
+        data = {
+            k.value: classes[k.value].parse(v)
+            for k, v in yaml_node.value.items()
+        }
+        return cls(data, yaml_node.loc)
+
+    @classmethod
+    def attrs(cls):
+        return cls.ATTRS
+
+    def __getattr__(self, key):
+        try:
+            return self.data[key]
+        except KeyError:
+            raise AttributeError(key)
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def __iter__(self):
+        return iter(self.data)
+
+    def dig(self, key, *subpath):
+        if key not in self.data:
+            return None
+        if not subpath:
+            return self.data[key]
+        return self.data[key].dig(*subpath)
+
+    def items(self):
+        return self.data.items()
+
+    def values(self):
+        return self.data.values()
+
+    @property
+    def bare(self):
+        return {k: v.bare for k, v in self.data.items()}
+
+
+class TypeEntity(Entity):
+    REFERENCE = None  # Override in subclasses
+
+    @classmethod
+    def validate(cls, yaml_node):
+        super().validate(yaml_node)
+        for key in yaml_node.value:
+            if key.value == "derived_from":
+                return
+        cls.abort("Type is missing derived_from key.", yaml_node.loc)
+
+    @classmethod
+    def attrs(cls):
+        assert isinstance(cls.REFERENCE, Reference), \
+            "Override REFERENCE in {} with Reference.".format(cls.__name__)
+
+        attributes = cls.ATTRS.copy()
+        attributes.update(
+            derived_from=cls.REFERENCE,
+            description=String,
+            metadata=Map(String),
+            version=Version,
+        )
+        return attributes

--- a/src/opera/parser/tosca/integer.py
+++ b/src/opera/parser/tosca/integer.py
@@ -1,0 +1,12 @@
+from .comparable import Comparable
+
+
+class Integer(Comparable):
+    @classmethod
+    def validate(cls, yaml_node):
+        super().validate(yaml_node)
+        if (
+                not isinstance(yaml_node.value, int) or
+                isinstance(yaml_node.value, bool)
+        ):
+            cls.abort("Expected integer.", yaml_node.loc)

--- a/src/opera/parser/tosca/list.py
+++ b/src/opera/parser/tosca/list.py
@@ -1,0 +1,35 @@
+from opera.error import ParseError
+
+from .base import Base
+
+
+class ListWrapper(Base):
+    def __getitem__(self, index):
+        return self.data[index]
+
+    def __iter__(self):
+        return iter(self.data)
+
+    def dig(self, key, *subpath):
+        try:
+            item = self.data[key]
+        except (IndexError, TypeError):
+            return None
+        return item.dig(*subpath) if subpath else item
+
+    @property
+    def bare(self):
+        return [v.bare for v in self.data]
+
+
+class List:
+    def __init__(self, value_class):
+        self.value_class = value_class
+
+    def parse(self, yaml_node):
+        if not isinstance(yaml_node.value, list):
+            raise ParseError("Expected list.", yaml_node.loc)
+
+        return ListWrapper([
+            self.value_class.parse(v) for v in yaml_node.value
+        ], yaml_node.loc)

--- a/src/opera/parser/tosca/map.py
+++ b/src/opera/parser/tosca/map.py
@@ -1,0 +1,69 @@
+import collections
+
+from opera.error import ParseError
+from opera.parser.yaml.node import Node
+
+from .base import Base
+
+
+class MapWrapper(Base):
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def __iter__(self):
+        return iter(self.data)
+
+    def values(self):
+        return self.data.values()
+
+    def keys(self):
+        return self.data.keys()
+
+    def items(self):
+        return self.data.items()
+
+    def dig(self, key, *subpath):
+        if key not in self.data:
+            return None
+        if not subpath:
+            return self.data[key]
+        return self.data[key].dig(*subpath)
+
+    @property
+    def bare(self):
+        return {k: v.bare for k, v in self.data.items()}
+
+
+
+class Map:
+    def __init__(self, value_class):
+        self.value_class = value_class
+
+    def parse(self, yaml_node):
+        if not isinstance(yaml_node.value, dict):
+            raise ParseError("Expected map.", yaml_node.loc)
+
+        for k in yaml_node.value:
+            if not isinstance(k.value, str):
+                cls.abort("Expected string key.", k.loc)
+
+        return MapWrapper(collections.OrderedDict(
+            (k.value, self.value_class.parse(v))
+            for k, v in yaml_node.value.items()
+        ), yaml_node.loc)
+
+
+class OrderedMap(Map):
+    def parse(self, yaml_node):
+        if not isinstance(yaml_node.value, list):
+            raise ParseError(
+                "Expected list of single-key maps.", yaml_node.loc,
+            )
+
+        data = collections.OrderedDict()
+        for item in yaml_node.value:
+            if not isinstance(item.value, dict) or len(item.value) != 1:
+                raise ParseError("Expected single-key map.", item.loc)
+            (k, v), = item.value.items()
+            data[k] = v
+        return super().parse(Node(data, yaml_node.loc))

--- a/src/opera/parser/tosca/reference.py
+++ b/src/opera/parser/tosca/reference.py
@@ -1,0 +1,22 @@
+from .string import String
+
+
+class ReferenceWrapper(String):
+    def __init__(self, data, loc):
+        super().__init__(data, loc)
+        self.section_path = ()
+
+
+class Reference:
+    def __init__(self, *section_path):
+        assert section_path, "Section path should not be empty"
+        for part in section_path:
+            assert isinstance(part, str), \
+                "Section path parts should be strings."
+
+        self.section_path = section_path
+
+    def parse(self, yaml_node):
+        ref = ReferenceWrapper.parse(yaml_node)
+        ref.section_path = self.section_path
+        return ref

--- a/src/opera/parser/tosca/string.py
+++ b/src/opera/parser/tosca/string.py
@@ -1,0 +1,9 @@
+from .comparable import Comparable
+
+
+class String(Comparable):
+    @classmethod
+    def validate(cls, yaml_node):
+        super().validate(yaml_node)
+        if not isinstance(yaml_node.value, str):
+            cls.abort("Expected string input", yaml_node.loc)

--- a/src/opera/parser/tosca/v_1_3/artifact_definition.py
+++ b/src/opera/parser/tosca/v_1_3/artifact_definition.py
@@ -1,0 +1,35 @@
+from opera.parser.yaml.node import Node
+
+from ..entity import Entity
+from ..map import Map
+from ..reference import Reference
+from ..string import String
+from ..version import Version
+from ..void import Void
+
+
+
+class ArtifactDefinition(Entity):
+    ATTRS = dict(
+        type=Reference("artifact_types"),
+        file=String,
+        repository=Reference("repositories"),
+        description=String,
+        deploy_path=String,
+        artifact_version=Version,
+        checksum=String,
+        checksum_algorithm=String,
+        properties=Map(Void),
+    )
+    REQUIRED = {"type", "file"}
+
+    @classmethod
+    def normalize(cls, yaml_node):
+        if not isinstance(yaml_node.value, (str, dict)):
+            cls.abort("Expected string or map.", yaml_node.loc)
+        if isinstance(yaml_node.value, str):
+            return Node({
+                Node("type"): Node("tosca.artifacts.File"),
+                Node("file"): yaml_node,
+            })
+        return yaml_node

--- a/src/opera/parser/tosca/v_1_3/artifact_type.py
+++ b/src/opera/parser/tosca/v_1_3/artifact_type.py
@@ -1,0 +1,16 @@
+from ..entity import TypeEntity
+from ..list import List
+from ..map import Map
+from ..reference import Reference
+from ..string import String
+
+from .property_definition import PropertyDefinition
+
+
+class ArtifactType(TypeEntity):
+    REFERENCE = Reference("artifact_types")
+    ATTRS = dict(
+        mime_type=String,
+        file_ext=List(String),
+        properties=Map(PropertyDefinition),
+    )

--- a/src/opera/parser/tosca/v_1_3/attribute_definition.py
+++ b/src/opera/parser/tosca/v_1_3/attribute_definition.py
@@ -1,0 +1,19 @@
+from ..entity import Entity
+from ..reference import Reference
+from ..string import String
+from ..void import Void
+
+from .schema_definition import SchemaDefinition
+from .status import Status
+
+
+class AttributeDefinition(Entity):
+    ATTRS = dict(
+        type=Reference("data_types"),
+        description=String,
+        default=Void,
+        status=Status,
+        key_schema=SchemaDefinition,
+        entry_schema=SchemaDefinition,
+    )
+    REQUIRED = {"type"}

--- a/src/opera/parser/tosca/v_1_3/capability_assignment.py
+++ b/src/opera/parser/tosca/v_1_3/capability_assignment.py
@@ -1,0 +1,14 @@
+from ..entity import Entity
+from ..map import Map
+from ..string import String
+from ..void import Void
+
+from .range import Range
+
+
+class CapabilityAssignment(Entity):
+    ATTRS = dict(
+        properties=Map(Void),
+        attributes=Map(Void),
+        occurrences=Range,
+    )

--- a/src/opera/parser/tosca/v_1_3/capability_definition.py
+++ b/src/opera/parser/tosca/v_1_3/capability_definition.py
@@ -1,0 +1,32 @@
+from opera.parser.yaml.node import Node
+
+from ..entity import Entity
+from ..reference import Reference
+from ..map import Map
+from ..list import List
+from ..string import String
+from ..void import Void
+
+from .attribute_definition import AttributeDefinition
+from .property_definition import PropertyDefinition
+from .range import Range
+
+
+class CapabilityDefinition(Entity):
+    ATTRS = dict(
+        type=Reference("capability_types"),
+        description=String,
+        properties=Map(PropertyDefinition),
+        attributes=Map(AttributeDefinition),
+        valid_source_types=List(Reference("node_types")),
+        occurrences=Range,
+    )
+    REQUIRED = {"type"}
+
+    @classmethod
+    def normalize(cls, yaml_node):
+        if not isinstance(yaml_node.value, (str, dict)):
+            cls.abort("Expected string or map.", yaml_node.loc)
+        if isinstance(yaml_node.value, str):
+            return Node({Node("type"): yaml_node})
+        return yaml_node

--- a/src/opera/parser/tosca/v_1_3/capability_type.py
+++ b/src/opera/parser/tosca/v_1_3/capability_type.py
@@ -1,0 +1,17 @@
+from ..entity import TypeEntity
+from ..list import List
+from ..map import Map
+from ..reference import Reference
+from ..string import String
+
+from .attribute_definition import AttributeDefinition
+from .property_definition import PropertyDefinition
+
+
+class CapabilityType(TypeEntity):
+    REFERENCE = Reference("capability_types")
+    ATTRS = dict(
+        properties=Map(PropertyDefinition),
+        attributes=Map(AttributeDefinition),
+        valid_source_types=List(Reference("node_types")),
+    )

--- a/src/opera/parser/tosca/v_1_3/constraint_clause.py
+++ b/src/opera/parser/tosca/v_1_3/constraint_clause.py
@@ -1,0 +1,25 @@
+from ..entity import Entity
+from ..void import Void
+
+
+class ConstraintClause(Entity):
+    ATTRS = dict(
+        equal=Void,
+        greater_than=Void,
+        greater_or_equal=Void,
+        less_than=Void,
+        less_or_equal=Void,
+        in_range=Void,
+        valid_values=Void,
+        length=Void,
+        min_length=Void,
+        max_length=Void,
+        pattern=Void,
+        schema=Void,
+    )
+
+    @classmethod
+    def validate(cls, yaml_node):
+        super().validate(yaml_node)
+        if len(yaml_node.value) != 1:
+            cls.abort("Expected single-pair map.", yaml_node.loc)

--- a/src/opera/parser/tosca/v_1_3/credential.py
+++ b/src/opera/parser/tosca/v_1_3/credential.py
@@ -1,0 +1,14 @@
+from ..entity import Entity
+from ..map import Map
+from ..string import String
+
+
+class Credential(Entity):
+    ATTRS = dict(
+        protocol=String,
+        token_type=String,
+        token=String,
+        keys=Map(String),
+        user=String,
+    )
+    REQUIRED = {"token"}

--- a/src/opera/parser/tosca/v_1_3/data_type.py
+++ b/src/opera/parser/tosca/v_1_3/data_type.py
@@ -1,0 +1,34 @@
+from opera.parser.yaml.node import Node
+
+from ..entity import TypeEntity
+from ..list import List
+from ..map import Map
+from ..reference import Reference
+from ..string import String
+
+from .constraint_clause import ConstraintClause
+from .property_definition import PropertyDefinition
+
+
+class DataType(TypeEntity):
+    REFERENCE = Reference("data_types")
+    ATTRS = dict(
+        constraints=List(ConstraintClause),
+        properties=Map(PropertyDefinition),
+    )
+
+    @classmethod
+    def normalize(cls, yaml_node):
+        # Let the validator handle non-dict case
+        if not isinstance(yaml_node.value, dict):
+            return yaml_node
+
+        # Make sure we have derived_from key
+        for k in yaml_node.value:
+            if k.value == "derived_from":
+                return yaml_node
+
+        # Create default derived_from spec if missing
+        data = {Node("derived_from"): Node("None")}
+        data.update(yaml_node.value)
+        return Node(data, yaml_node.loc)

--- a/src/opera/parser/tosca/v_1_3/group_definition.py
+++ b/src/opera/parser/tosca/v_1_3/group_definition.py
@@ -1,0 +1,17 @@
+from ..entity import Entity
+from ..list import List
+from ..map import Map
+from ..reference import Reference
+from ..string import String
+from ..void import Void
+
+
+class GroupDefinition(Entity):
+    ATTRS = dict(
+        type=Reference("group_types"),
+        description=String,
+        metadata=Map(String),
+        properties=Map(Void),
+        members=List(Reference("topology_template", "node_templates")),
+    )
+    REQUIRED = {"type"}

--- a/src/opera/parser/tosca/v_1_3/group_type.py
+++ b/src/opera/parser/tosca/v_1_3/group_type.py
@@ -1,0 +1,17 @@
+from ..entity import TypeEntity
+from ..list import List
+from ..map import Map
+from ..reference import Reference
+from ..string import String
+
+from .attribute_definition import AttributeDefinition
+from .property_definition import PropertyDefinition
+
+
+class GroupType(TypeEntity):
+    REFERENCE = Reference("group_types")
+    ATTRS = dict(
+        attributes=Map(AttributeDefinition),
+        properties=Map(PropertyDefinition),
+        members=List(Reference("node_types")),
+    )

--- a/src/opera/parser/tosca/v_1_3/import_definition.py
+++ b/src/opera/parser/tosca/v_1_3/import_definition.py
@@ -1,0 +1,26 @@
+from opera.parser.yaml.node import Node
+
+from ..entity import Entity
+from ..string import String
+
+
+class ImportDefinition(Entity):
+    ATTRS = dict(
+        file=String,
+        repository=String,
+        namespace_prefix=String,
+        namespace_uri=String,
+    )
+    DEPRECATED = {
+        "namespace_uri",
+    }
+
+    @classmethod
+    def normalize(cls, yaml_node):
+        if not isinstance(yaml_node.value, (str, dict)):
+            cls.abort(
+                "Invalid import data. Expected string or dict.", yaml_node.loc,
+            )
+        if isinstance(yaml_node.value, str):
+            return Node({Node("file"): yaml_node})
+        return yaml_node

--- a/src/opera/parser/tosca/v_1_3/interface_definition_for_template.py
+++ b/src/opera/parser/tosca/v_1_3/interface_definition_for_template.py
@@ -1,0 +1,15 @@
+from ..entity import Entity
+from ..map import Map
+from ..string import String
+from ..void import Void
+
+from .notification_definition import NotificationDefinition
+from .operation_definition_for_template import OperationDefinitionForTemplate
+
+
+class InterfaceDefinitionForTemplate(Entity):
+    ATTRS = dict(
+        inputs=Map(Void),
+        operations=Map(OperationDefinitionForTemplate),
+        notifications=Map(NotificationDefinition),
+    )

--- a/src/opera/parser/tosca/v_1_3/interface_definition_for_type.py
+++ b/src/opera/parser/tosca/v_1_3/interface_definition_for_type.py
@@ -1,0 +1,17 @@
+from ..entity import Entity
+from ..map import Map
+from ..reference import Reference
+from ..string import String
+
+from .notification_definition import NotificationDefinition
+from .operation_definition_for_type import OperationDefinitionForType
+from .property_definition import PropertyDefinition
+
+
+class InterfaceDefinitionForType(Entity):
+    ATTRS = dict(
+        type=Reference("interface_types"),
+        inputs=Map(PropertyDefinition),
+        operations=Map(OperationDefinitionForType),
+        notifications=Map(NotificationDefinition),
+    )

--- a/src/opera/parser/tosca/v_1_3/interface_type.py
+++ b/src/opera/parser/tosca/v_1_3/interface_type.py
@@ -1,0 +1,17 @@
+from ..entity import TypeEntity
+from ..map import Map
+from ..reference import Reference
+from ..string import String
+
+from .notification_definition import NotificationDefinition
+from .operation_definition_for_type import OperationDefinitionForType
+from .property_definition import PropertyDefinition
+
+
+class InterfaceType(TypeEntity):
+    REFERENCE = Reference("interface_types")
+    ATTRS = dict(
+        inputs=Map(PropertyDefinition),
+        operations=Map(OperationDefinitionForType),
+        notifications=Map(NotificationDefinition),
+    )

--- a/src/opera/parser/tosca/v_1_3/node_filter_definition.py
+++ b/src/opera/parser/tosca/v_1_3/node_filter_definition.py
@@ -1,0 +1,15 @@
+from ..entity import Entity
+from ..list import List
+from ..void import Void
+
+
+# NOTE: This is more or less unimplemented, since we do not intend to support
+# node filtering. Official grammar for filters being a complete garbage only
+# makes our decision of not supporting them easier to defend.
+
+
+class NodeFilterDefinition(Entity):
+    ATTRS = dict(
+        properties=List(Void),
+        capabilities=List(Void),
+    )

--- a/src/opera/parser/tosca/v_1_3/node_template.py
+++ b/src/opera/parser/tosca/v_1_3/node_template.py
@@ -1,0 +1,35 @@
+from ..entity import Entity
+from ..list import List
+from ..map import Map, OrderedMap
+from ..reference import Reference
+from ..string import String
+from ..void import Void
+
+from .artifact_definition import ArtifactDefinition
+from .capability_assignment import CapabilityAssignment
+from .interface_definition_for_template import InterfaceDefinitionForTemplate
+from .node_filter_definition import NodeFilterDefinition
+from .requirement_assignment import RequirementAssignment
+
+
+# NOTE: We deviate form the TOSCA standard in attribute assignment statement,
+# since the official grammar is just ridiculous (it makes assigning complex
+# values impossible in simplified form).
+
+
+class NodeTemplate(Entity):
+    ATTRS = dict(
+        type=Reference("node_types"),
+        description=String,
+        metadata=Map(String),
+        directives=List(String),
+        properties=Map(Void),
+        attributes=Map(Void),
+        requirements=OrderedMap(RequirementAssignment),
+        capabilities=Map(CapabilityAssignment),
+        interfaces=Map(InterfaceDefinitionForTemplate),
+        artifacts=Map(ArtifactDefinition),
+        node_filter=NodeFilterDefinition,
+        copy=Reference("topology_template", "node_templates"),
+    )
+    REQUIRED = {"type"}

--- a/src/opera/parser/tosca/v_1_3/node_type.py
+++ b/src/opera/parser/tosca/v_1_3/node_type.py
@@ -1,0 +1,23 @@
+from ..entity import TypeEntity
+from ..map import Map, OrderedMap
+from ..reference import Reference
+from ..string import String
+
+from .artifact_definition import ArtifactDefinition
+from .attribute_definition import AttributeDefinition
+from .capability_definition import CapabilityDefinition
+from .interface_definition_for_type import InterfaceDefinitionForType
+from .property_definition import PropertyDefinition
+from .requirement_definition import RequirementDefinition
+
+
+class NodeType(TypeEntity):
+    REFERENCE = Reference("node_types")
+    ATTRS = dict(
+        attributes=Map(AttributeDefinition),
+        properties=Map(PropertyDefinition),
+        requirements=OrderedMap(RequirementDefinition),
+        capabilities=Map(CapabilityDefinition),
+        interfaces=Map(InterfaceDefinitionForType),
+        artifacts=Map(ArtifactDefinition),
+    )

--- a/src/opera/parser/tosca/v_1_3/notification_definition.py
+++ b/src/opera/parser/tosca/v_1_3/notification_definition.py
@@ -1,0 +1,17 @@
+from ..entity import Entity
+from ..string import String
+from ..list import List
+from ..map import Map
+from ..void import Void
+
+from .notification_implementation_definition import (
+    NotificationImplementationDefinition,
+)
+
+
+class NotificationDefinition(Entity):
+    ATTRS = dict(
+        description=String,
+        implementation=NotificationImplementationDefinition,
+        outputs=Map(List(Void)),
+    )

--- a/src/opera/parser/tosca/v_1_3/notification_implementation_definition.py
+++ b/src/opera/parser/tosca/v_1_3/notification_implementation_definition.py
@@ -1,0 +1,21 @@
+from opera.parser.yaml.node import Node
+
+from ..entity import Entity
+from ..list import List
+
+from .artifact_definition import ArtifactDefinition
+
+
+class NotificationImplementationDefinition(Entity):
+    ATTRS = dict(
+        primary=ArtifactDefinition,
+        dependencies=List(ArtifactDefinition),
+    )
+
+    @classmethod
+    def normalize(cls, yaml_node):
+        if not isinstance(yaml_node.value, (str, dict)):
+            cls.abort("Expected string or map.", yaml_node.loc)
+        if isinstance(yaml_node.value, str):
+            return Node({Node("primary"): yaml_node})
+        return yaml_node

--- a/src/opera/parser/tosca/v_1_3/operation_definition_for_template.py
+++ b/src/opera/parser/tosca/v_1_3/operation_definition_for_template.py
@@ -1,0 +1,28 @@
+from opera.parser.yaml.node import Node
+
+from ..entity import Entity
+from ..list import List
+from ..map import Map
+from ..string import String
+from ..void import Void
+
+from .operation_implementation_definition import (
+    OperationImplementationDefinition,
+)
+
+
+class OperationDefinitionForTemplate(Entity):
+    ATTRS = dict(
+        description=String,
+        implementation=OperationImplementationDefinition,
+        inputs=Map(Void),
+        outputs=Map(List(Void)),
+    )
+
+    @classmethod
+    def normalize(cls, yaml_node):
+        if not isinstance(yaml_node.value, (str, dict)):
+            cls.abort("Expected string or map.", yaml_node.loc)
+        if isinstance(yaml_node.value, str):
+            return Node({Node("implementation"): yaml_node})
+        return yaml_node

--- a/src/opera/parser/tosca/v_1_3/operation_definition_for_type.py
+++ b/src/opera/parser/tosca/v_1_3/operation_definition_for_type.py
@@ -1,0 +1,29 @@
+from opera.parser.yaml.node import Node
+
+from ..entity import Entity
+from ..list import List
+from ..map import Map
+from ..string import String
+from ..void import Void
+
+from .operation_implementation_definition import (
+    OperationImplementationDefinition,
+)
+from .parameter_definition import ParameterDefinition
+
+
+class OperationDefinitionForType(Entity):
+    ATTRS = dict(
+        description=String,
+        implementation=OperationImplementationDefinition,
+        inputs=Map(ParameterDefinition),
+        outputs=Map(List(Void)),
+    )
+
+    @classmethod
+    def normalize(cls, yaml_node):
+        if not isinstance(yaml_node.value, (str, dict)):
+            cls.abort("Expected string or map.", yaml_node.loc)
+        if isinstance(yaml_node.value, str):
+            return Node({Node("implementation"): yaml_node})
+        return yaml_node

--- a/src/opera/parser/tosca/v_1_3/operation_host.py
+++ b/src/opera/parser/tosca/v_1_3/operation_host.py
@@ -1,0 +1,15 @@
+from ..string import String
+
+
+class OperationHost(String):
+    VALID_HOSTS = {"SELF", "HOST", "SOURCE", "TARGET", "ORCHESTRATOR"}
+
+    @classmethod
+    def validate(cls, yaml_node):
+        super().validate(yaml_node)
+        if yaml_node.value not in cls.VALID_HOSTS:
+            cls.abort(
+                "Invalid operation host: {}. Use any from: {}".format(
+                    yaml_node.value, ", ".join(cls.VALID_HOSTS),
+                ), yaml_node.loc,
+            )

--- a/src/opera/parser/tosca/v_1_3/operation_implementation_definition.py
+++ b/src/opera/parser/tosca/v_1_3/operation_implementation_definition.py
@@ -1,0 +1,25 @@
+from opera.parser.yaml.node import Node
+
+from ..entity import Entity
+from ..integer import Integer
+from ..list import List
+
+from .artifact_definition import ArtifactDefinition
+from .operation_host import OperationHost
+
+
+class OperationImplementationDefinition(Entity):
+    ATTRS = dict(
+        primary=ArtifactDefinition,
+        dependencies=List(ArtifactDefinition),
+        timeout=Integer,
+        operation_host=OperationHost,
+    )
+
+    @classmethod
+    def normalize(cls, yaml_node):
+        if not isinstance(yaml_node.value, (str, dict)):
+            cls.abort("Expected string or map.", yaml_node.loc)
+        if isinstance(yaml_node.value, str):
+            return Node({Node("primary"): yaml_node})
+        return yaml_node

--- a/src/opera/parser/tosca/v_1_3/parameter_definition.py
+++ b/src/opera/parser/tosca/v_1_3/parameter_definition.py
@@ -1,0 +1,32 @@
+from ..bool import Bool
+from ..entity import Entity
+from ..list import List
+from ..map import Map
+from ..reference import Reference
+from ..string import String
+from ..void import Void
+
+
+from .constraint_clause import ConstraintClause
+from .schema_definition import SchemaDefinition
+from .status import Status
+
+
+# TODO(@tadeboro): Unify ParameterDefinition and PropertyDefinition and add
+# runtime checks. Refinement will be a PITA ...
+
+
+class ParameterDefinition(Entity):
+    ATTRS = dict(
+        type=Reference("data_types"),
+        description=String,
+        required=Bool,
+        default=Void,
+        status=Status,
+        constraints=List(ConstraintClause),
+        key_schema=SchemaDefinition,
+        entry_schema=SchemaDefinition,
+        external_schema=String,
+        metadata=Map(String),
+        value=Void,
+    )

--- a/src/opera/parser/tosca/v_1_3/policy_definition.py
+++ b/src/opera/parser/tosca/v_1_3/policy_definition.py
@@ -1,0 +1,16 @@
+from ..entity import Entity
+from ..map import Map
+from ..reference import Reference
+from ..string import String
+from ..void import Void
+
+
+class PolicyDefinition(Entity):
+    ATTRS = dict(
+        type=Reference("policy_types"),
+        description=String,
+        metadata=Map(String),
+        properties=Map(Void),
+        # TODO(@tadeboro): targets, triggers
+    )
+    REQUIRED = {"type"}

--- a/src/opera/parser/tosca/v_1_3/policy_type.py
+++ b/src/opera/parser/tosca/v_1_3/policy_type.py
@@ -1,0 +1,14 @@
+from ..entity import TypeEntity
+from ..map import Map
+from ..reference import Reference
+from ..string import String
+
+from .property_definition import PropertyDefinition
+
+
+class PolicyType(TypeEntity):
+    REFERENCE = Reference("policy_types")
+    ATTRS = dict(
+        properties=Map(PropertyDefinition),
+        # TODOD(@tadeboro): Add targets, triggers
+    )

--- a/src/opera/parser/tosca/v_1_3/property_definition.py
+++ b/src/opera/parser/tosca/v_1_3/property_definition.py
@@ -1,0 +1,27 @@
+from ..bool import Bool
+from ..entity import Entity
+from ..list import List
+from ..map import Map
+from ..reference import Reference
+from ..string import String
+from ..void import Void
+
+from .constraint_clause import ConstraintClause
+from .schema_definition import SchemaDefinition
+from .status import Status
+
+
+class PropertyDefinition(Entity):
+    ATTRS = dict(
+        type=Reference("data_types"),
+        description=String,
+        required=Bool,
+        default=Void,
+        status=Status,
+        constraints=List(ConstraintClause),
+        key_schema=SchemaDefinition,
+        entry_schema=SchemaDefinition,
+        external_schema=String,
+        metadata=Map(String),
+    )
+    REQUIRED = {"type"}

--- a/src/opera/parser/tosca/v_1_3/range.py
+++ b/src/opera/parser/tosca/v_1_3/range.py
@@ -1,0 +1,42 @@
+import math
+
+from ..base import Base
+
+
+# NOTE: We do some pretty horrible checks in the validate function. There are
+# two reasons for this mess:
+#
+#  1. TOSCA's range type is a bit ugly to parse because upper bound can be
+#     string (UNBOUNDED) and should be treated as infinity.
+#  2. Python's bool type subclasses int, which makes isinstance(False, int)
+#     truthy. Thsi is why we have separate checks for bool.
+
+class Range(Base):
+    @classmethod
+    def validate(cls, yaml_node):
+        if not isinstance(yaml_node.value, list) or len(yaml_node.value) != 2:
+            cls.abort("Expected two element list.", yaml_node.loc)
+
+        lo, hi = yaml_node.value
+        if not isinstance(lo.value, int) or isinstance(lo.value, bool):
+            cls.abort("Lower bound must be integer.", lo.loc)
+
+        if isinstance(hi.value, str) and hi.value != "UNBOUNDED":
+            cls.abort("Upper bound must be integer or UNBOUNDED.", hi.loc)
+
+        if not isinstance(hi.value, (str, int)) or isinstance(hi.value, bool):
+            cls.abort("Upper bound must be integer or UNBOUNDED.", hi.loc)
+
+        if isinstance(hi.value, int) and lo.value > hi.value:
+            cls.abort(
+                "Upper bound must be greater or equal to lower bound.",
+                yaml_node.loc,
+            )
+
+    @classmethod
+    def build(cls, yaml_node):
+        lo, hi = yaml_node.value
+        return cls(
+            (lo.value, math.inf if hi.value == "UNBOUNDED" else hi.value),
+            yaml_node.loc,
+        )

--- a/src/opera/parser/tosca/v_1_3/relationship_template.py
+++ b/src/opera/parser/tosca/v_1_3/relationship_template.py
@@ -1,0 +1,20 @@
+from ..entity import Entity
+from ..map import Map
+from ..reference import Reference
+from ..string import String
+from ..void import Void
+
+from .interface_definition_for_template import InterfaceDefinitionForTemplate
+
+
+class RelationshipTemplate(Entity):
+    ATTRS = dict(
+        type=Reference("relationship_types"),
+        description=String,
+        metadata=Map(String),
+        properties=Map(Void),
+        attributes=Map(Void),
+        interfaces=Map(InterfaceDefinitionForTemplate),
+        copy=Reference("topology_template", "relationship_templates"),
+    )
+    REQUIRED = {"type"}

--- a/src/opera/parser/tosca/v_1_3/relationship_type.py
+++ b/src/opera/parser/tosca/v_1_3/relationship_type.py
@@ -1,0 +1,19 @@
+from ..entity import TypeEntity
+from ..list import List
+from ..map import Map
+from ..reference import Reference
+from ..string import String
+
+from .attribute_definition import AttributeDefinition
+from .interface_definition_for_type import InterfaceDefinitionForType
+from .property_definition import PropertyDefinition
+
+
+class RelationshipType(TypeEntity):
+    REFERENCE = Reference("relationship_types")
+    ATTRS = dict(
+        properties=Map(PropertyDefinition),
+        attributes=Map(AttributeDefinition),
+        interfaces=Map(InterfaceDefinitionForType),
+        valid_target_types=List(Reference("capability_types")),
+    )

--- a/src/opera/parser/tosca/v_1_3/repository_definition.py
+++ b/src/opera/parser/tosca/v_1_3/repository_definition.py
@@ -1,0 +1,26 @@
+from opera.parser.yaml.node import Node
+
+from ..entity import Entity
+from ..string import String
+
+from .credential import Credential
+
+
+class RepositoryDefinition(Entity):
+    ATTRS = dict(
+        description=String,
+        url=String,
+        credential=Credential,
+    )
+    REQUIRED = {"url"}
+
+    @classmethod
+    def normalize(cls, yaml_node):
+        if not isinstance(yaml_node.value, (str, dict)):
+            cls.abort(
+                "Invalid repository data. Expected string or dict.",
+                yaml_node.loc,
+            )
+        if isinstance(yaml_node.value, str):
+            return Node({Node("url"): yaml_node})
+        return yaml_node

--- a/src/opera/parser/tosca/v_1_3/requirement_assignment.py
+++ b/src/opera/parser/tosca/v_1_3/requirement_assignment.py
@@ -1,0 +1,27 @@
+from opera.parser.yaml.node import Node
+
+from ..entity import Entity
+from ..reference import Reference
+from ..string import String
+from ..void import Void
+
+from .node_filter_definition import NodeFilterDefinition
+from .range import Range
+
+
+class RequirementAssignment(Entity):
+    ATTRS = dict(
+        capability=String,
+        node=Reference("topology_template", "node_templates"),
+        relationship=Reference("topology_template", "relationship_templates"),
+        node_filter=NodeFilterDefinition,
+        occurrences=Range,
+    )
+
+    @classmethod
+    def normalize(cls, yaml_node):
+        if not isinstance(yaml_node.value, (str, dict)):
+            cls.abort("Expected string or map.", yaml_node.loc)
+        if isinstance(yaml_node.value, str):
+            return Node({Node("node"): yaml_node})
+        return yaml_node

--- a/src/opera/parser/tosca/v_1_3/requirement_definition.py
+++ b/src/opera/parser/tosca/v_1_3/requirement_definition.py
@@ -1,0 +1,24 @@
+from opera.parser.yaml.node import Node
+
+from ..entity import Entity
+from ..reference import Reference
+
+from .range import Range
+
+
+class RequirementDefinition(Entity):
+    ATTRS = dict(
+        capability=Reference("capability_types"),
+        node=Reference("node_types"),
+        relationship=Reference("relationship_types"),
+        occurrences=Range,
+    )
+    REQUIRED = {"capability"}
+
+    @classmethod
+    def normalize(cls, yaml_node):
+        if not isinstance(yaml_node.value, (str, dict)):
+            cls.abort("Expected string or map.", yaml_node.loc)
+        if isinstance(yaml_node.value, str):
+            return Node({Node("capability"): yaml_node})
+        return yaml_node

--- a/src/opera/parser/tosca/v_1_3/schema_definition.py
+++ b/src/opera/parser/tosca/v_1_3/schema_definition.py
@@ -1,0 +1,15 @@
+from ..entity import Entity
+from ..list import List
+from ..reference import Reference
+from ..string import String
+
+from .constraint_clause import ConstraintClause
+
+
+class SchemaDefinition(Entity):
+    ATTRS = dict(
+        type=Reference("data_types"),
+        description=String,
+        constraints=List(ConstraintClause),
+    )
+    REQUIRED = {"type"}

--- a/src/opera/parser/tosca/v_1_3/service_template.py
+++ b/src/opera/parser/tosca/v_1_3/service_template.py
@@ -1,0 +1,55 @@
+import pathlib
+
+from opera.parser.yaml.node import Node
+
+from ..entity import Entity
+from ..list import List
+from ..map import Map
+from ..string import String
+
+from .artifact_type import ArtifactType
+from .capability_type import CapabilityType
+from .data_type import DataType
+from .group_type import GroupType
+from .import_definition import ImportDefinition
+from .interface_type import InterfaceType
+from .node_type import NodeType
+from .policy_type import PolicyType
+from .relationship_type import RelationshipType
+from .repository_definition import RepositoryDefinition
+from .topology_template import TopologyTemplate
+from .tosca_definitions_version import ToscaDefinitionsVersion
+
+
+class ServiceTemplate(Entity):
+    ATTRS = dict(
+        tosca_definitions_version=ToscaDefinitionsVersion,
+        namespace=String,
+        metadata=Map(String),
+        description=String,
+        # dsl_definitions have already been taken care of by the YAML parser
+        repositories=Map(RepositoryDefinition),
+        imports=List(ImportDefinition),
+        artifact_types=Map(ArtifactType),
+        data_types=Map(DataType),
+        capability_types=Map(CapabilityType),
+        interface_types=Map(InterfaceType),
+        relationship_types=Map(RelationshipType),
+        node_types=Map(NodeType),
+        group_types=Map(GroupType),
+        policy_types=Map(PolicyType),
+        topology_template=TopologyTemplate,
+    )
+    REQUIRED = {"tosca_definitions_version"}
+
+    @classmethod
+    def normalize(cls, yaml_node):
+        if not isinstance(yaml_node.value, dict):
+            cls.abort("TOSCA document should be a map.", yaml_node.loc)
+
+        # Filter out dsl_definitions, since they are preprocessor construct.
+        return Node({
+            k: v
+            for k, v in yaml_node.value.items()
+            if k.value != "dsl_definitions"
+        }, yaml_node.loc)

--- a/src/opera/parser/tosca/v_1_3/status.py
+++ b/src/opera/parser/tosca/v_1_3/status.py
@@ -1,0 +1,13 @@
+from ..string import String
+
+
+class Status(String):
+    VALID_STATES = {"supported", "unsupported", "experimental", "deprecated"}
+
+    @classmethod
+    def validate(cls, yaml_node):
+        super().validate(yaml_node)
+        if yaml_node.value not in cls.VALID_STATES:
+            cls.abort(
+                "Invalid state: '{}'.".format(yaml_node.value), yaml_node.loc,
+            )

--- a/src/opera/parser/tosca/v_1_3/topology_template.py
+++ b/src/opera/parser/tosca/v_1_3/topology_template.py
@@ -1,0 +1,22 @@
+from ..entity import Entity
+from ..map import Map
+from ..string import String
+
+from .group_definition import GroupDefinition
+from .node_template import NodeTemplate
+from .parameter_definition import ParameterDefinition
+from .policy_definition import PolicyDefinition
+from .relationship_template import RelationshipTemplate
+
+
+class TopologyTemplate(Entity):
+    ATTRS = dict(
+        description=String,
+        inputs=Map(ParameterDefinition),
+        node_templates=Map(NodeTemplate),
+        relationship_templates=Map(RelationshipTemplate),
+        groups=Map(GroupDefinition),
+        policies=Map(PolicyDefinition),
+        outputs=Map(ParameterDefinition),
+        # TODO(@tadeboro): substitution_mappings and workflows
+    )

--- a/src/opera/parser/tosca/v_1_3/tosca_definitions_version.py
+++ b/src/opera/parser/tosca/v_1_3/tosca_definitions_version.py
@@ -1,0 +1,16 @@
+from ..string import String
+
+
+class ToscaDefinitionsVersion(String):
+    @classmethod
+    def validate(cls, yaml_node):
+        super().validate(yaml_node)
+        if yaml_node.value != "tosca_simple_yaml_1_3":
+            cls.abort(
+                "Invalid TOSCA version: {}. Expected {}.".format(
+                    yaml_node.value, "tosca_simple_yaml_1_3",
+                ), yaml_node.loc,
+            )
+
+    def eval(self, _reference):
+        return self.data

--- a/src/opera/parser/tosca/version.py
+++ b/src/opera/parser/tosca/version.py
@@ -1,0 +1,42 @@
+import re
+
+from .string import String
+
+
+# TOSCA definition: <major>.<minor>[.<fix>[.<qualifier>[-<build]]]
+#   major: is a required integer value greater than or equal to 0 (zero)
+#   minor: is a required integer value greater than or equal to 0 (zero).
+#   fix: is an optional integer value greater than or equal to 0 (zero).
+#   qualifier: is an optional string that indicates a named, pre-release
+#              version of the associated code that has been derived from the
+#              version of the code identified by the combination
+#              major_version, minor_version and fix_version numbers.
+#   build: is an optional integer value greater than or equal to 0 (zero) that
+#          can be used to further qualify different build versions of the code
+#          that has the same qualifer_string.
+VERSION_RE = re.compile(
+    r"""
+    ^
+      (?P<major>[0-9]|([1-9][0-9]+))
+    \.(?P<minor>[0-9]|([1-9][0-9]+))
+    (
+        \.(?P<fix>[0-9]|([1-9][0-9]+))
+        (
+            \.(?P<qualifier>\w+)
+            (
+                -(?P<build>[0-9]|([1-9][0-9]+))
+            )?
+        )?
+    )?
+    $
+    """,
+    re.ASCII | re.VERBOSE,
+)
+
+
+class Version(String):
+    @classmethod
+    def validate(cls, yaml_node):
+        super().validate(yaml_node)
+        if not VERSION_RE.match(yaml_node.value):
+            cls.abort("Invalid version format.", yaml_node.loc)

--- a/src/opera/parser/tosca/void.py
+++ b/src/opera/parser/tosca/void.py
@@ -1,0 +1,14 @@
+from opera.parser.yaml.node import Node
+
+from .base import Base
+
+
+class Void(Base):
+    """
+    Marker for parts of the document that should be parsed after initial
+    semantic analysis.
+    """
+
+    @property
+    def bare(self):
+        return Node(self.data, self.loc).bare

--- a/src/opera/parser/yaml/constructor.py
+++ b/src/opera/parser/yaml/constructor.py
@@ -1,5 +1,7 @@
 from yaml.constructor import BaseConstructor, ConstructorError
 
+from opera.parser.utils.location import Location
+
 from .node import Node
 
 
@@ -10,19 +12,19 @@ class Constructor(BaseConstructor):
 
     def _pos(self, node):
         # Convert 0-based indices to 1-based (text editor) marks
-        return dict(
-            stream_name=self._stream_name,
-            line=node.start_mark.line + 1,
-            column=node.start_mark.column + 1,
+        return Location(
+            self._stream_name,
+            node.start_mark.line + 1,
+            node.start_mark.column + 1,
         )
 
     def construct_yaml_null(self, node):
         self.construct_scalar(node)
-        return Node(None, **self._pos(node))
+        return Node(None, self._pos(node))
 
     def construct_yaml_bool(self, node):
         value = self.construct_scalar(node).lower()
-        return Node(value == "true", **self._pos(node))
+        return Node(value == "true", self._pos(node))
 
     def construct_yaml_int(self, node):
         value = self.construct_scalar(node)
@@ -32,7 +34,7 @@ class Constructor(BaseConstructor):
             base = 16
         else:
             base = 10
-        return Node(int(value, base=base), **self._pos(node))
+        return Node(int(value, base=base), self._pos(node))
 
     def construct_yaml_float(self, node):
         value = self.construct_scalar(node).lower()
@@ -40,18 +42,18 @@ class Constructor(BaseConstructor):
             value = "nan"
         elif value.endswith(".inf"):
             value = value.replace(".", "")
-        return Node(float(value), **self._pos(node))
+        return Node(float(value), self._pos(node))
 
     def construct_yaml_str(self, node):
-        return Node(self.construct_scalar(node), **self._pos(node))
+        return Node(self.construct_scalar(node), self._pos(node))
 
     def construct_yaml_seq(self, node):
-        data = Node([], **self._pos(node))
+        data = Node([], self._pos(node))
         yield data
         data.value.extend(self.construct_sequence(node))
 
     def construct_yaml_map(self, node):
-        data = Node({}, **self._pos(node))
+        data = Node({}, self._pos(node))
         yield data
         data.value.update(self.construct_mapping(node))
 

--- a/src/opera/parser/yaml/node.py
+++ b/src/opera/parser/yaml/node.py
@@ -2,9 +2,9 @@ from opera.parser.utils.location import Location
 
 
 class Node:
-    def __init__(self, value, stream_name, line, column):
+    def __init__(self, value, loc=None):
         self.value = value
-        self.loc = Location(stream_name, line, column)
+        self.loc = loc or Location("", 0, 0)
 
     def _dump_header(self):
         return "{}({})".format(type(self.value).__name__, self.loc)

--- a/tests/opera/parser/tosca/conftest.py
+++ b/tests/opera/parser/tosca/conftest.py
@@ -1,0 +1,12 @@
+import textwrap
+
+import pytest
+
+from opera.parser import yaml
+
+
+@pytest.fixture
+def yaml_ast():
+    def _yaml_ast(string_data):
+        return yaml.load(textwrap.dedent(string_data), "TEST")
+    return _yaml_ast

--- a/tests/opera/parser/tosca/test_base.py
+++ b/tests/opera/parser/tosca/test_base.py
@@ -1,0 +1,68 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.base import Base
+from opera.parser.utils.location import Location
+from opera.parser.yaml.node import Node
+
+
+class TestParse:
+    @pytest.mark.parametrize(
+        "data", ["", 4, "a", (), (1, 2, 3), [], ["a", "b"]],
+    )
+    def test_creates_new_instance(self, data):
+        obj = Base.parse(Node(data, Location("s", 1, 2)))
+
+        assert obj.data == data
+        assert obj.loc.stream_name == "s"
+        assert obj.loc.line == 1
+        assert obj.loc.column == 2
+
+
+class TestNormalize:
+    @pytest.mark.parametrize(
+        "data", ["", 4, "a", (), (1, 2, 3), [], ["a", "b"]],
+    )
+    def test_normalize_is_noop(self, data):
+        assert Base.normalize(data) == data
+
+
+class TestValidate:
+    @pytest.mark.parametrize(
+        "data", ["", 4, "a", (), (1, 2, 3), [], ["a", "b"]],
+    )
+    def test_validate_is_always_ok(self, data):
+        Base.validate(data)
+
+
+class TestBuild:
+    @pytest.mark.parametrize(
+        "data", ["", 4, "a", (), (1, 2, 3), [], ["a", "b"]],
+    )
+    def test_build_creates_new_instance(self, data):
+        obj = Base.build(Node(data, Location("stream", 1, 2)))
+
+        assert obj.data == data
+        assert obj.loc.stream_name == "stream"
+        assert obj.loc.line == 1
+        assert obj.loc.column == 2
+
+
+class TestAbort:
+    def test_abort(self):
+        with pytest.raises(ParseError, match="Error MsG"):
+            Base.abort("Error MsG", None)
+
+
+class TestBare:
+    @pytest.mark.parametrize(
+        "data", ["", 4, "a", (), (1, 2, 3), [], ["a", "b"]],
+    )
+    def test_bare(self, data):
+        assert Base(data, None).bare == data
+
+
+class TestStr:
+    @pytest.mark.parametrize("data", [1, 2.3, True, "abc", {}, []])
+    def test_str(self, data):
+        assert str(data) == str(Base(data, Location("s", 4, 5)))

--- a/tests/opera/parser/tosca/test_bool.py
+++ b/tests/opera/parser/tosca/test_bool.py
@@ -1,0 +1,18 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.bool import Bool
+from opera.parser.yaml.node import Node
+
+
+class TestValidate:
+    @pytest.mark.parametrize("data", [True, False])
+    def test_with_bool_data(self, data):
+        Bool.validate(Node(data))
+
+    @pytest.mark.parametrize(
+        "data", [4,  (), (1, 2, 3), [], ["a", "b"], {}],
+    )
+    def test_with_non_bool_data(self, data):
+        with pytest.raises(ParseError):
+            Bool.validate(Node(data))

--- a/tests/opera/parser/tosca/test_comparable.py
+++ b/tests/opera/parser/tosca/test_comparable.py
@@ -1,0 +1,19 @@
+import pytest
+
+from opera.parser.tosca.comparable import Comparable
+
+
+class TestEquality:
+    @pytest.mark.parametrize("data", [1, 2.3, "abc", (), [], {}])
+    def test_ok(self, data):
+        assert Comparable(data, None) == Comparable(data, None)
+
+    @pytest.mark.parametrize("data", [1, 2.3, "abc", (), [], {}])
+    def test_not_ok(self, data):
+        assert Comparable(data, None) != Comparable("NOT EQUAL", None)
+
+
+class TestHash:
+    @pytest.mark.parametrize("data", [1, 2.3, "abc", ()])
+    def test_ok(self, data):
+        assert hash(Comparable(data, None)) == hash(Comparable(data, None))

--- a/tests/opera/parser/tosca/test_entity.py
+++ b/tests/opera/parser/tosca/test_entity.py
@@ -1,0 +1,181 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.base import Base
+from opera.parser.tosca.entity import Entity, TypeEntity
+from opera.parser.tosca.reference import Reference
+from opera.parser.yaml.node import Node
+
+
+class DummyAttr(Base):
+    pass
+
+
+class DummyEntity(Entity):
+    ATTRS = dict(
+        required=DummyAttr,
+        optional=DummyAttr,
+    )
+    REQUIRED = {"required"}
+
+
+class TestEntityValidate:
+    @pytest.mark.parametrize("data", [1, 3.4, "", "a", (), []])
+    def test_non_dict_data_is_invalid(self, data):
+        with pytest.raises(ParseError):
+            DummyEntity.validate(Node(data))
+
+    @pytest.mark.parametrize("key", [1, 3.4, False, None, (), []])
+    def test_non_string_keys_are_invalid(self, key):
+        with pytest.raises(ParseError):
+            DummyEntity.validate(Node(key))
+
+    def test_non_declared_attrs_fail(self):
+        with pytest.raises(ParseError, match="non_declared_attr"):
+            DummyEntity.validate(Node({
+                Node("required"): Node("value"),
+                Node("non_declared_attr"): Node(3),
+            }))
+
+    def test_required_attrs(self):
+        with pytest.raises(ParseError, match="required"):
+            DummyEntity.validate(Node({}))
+
+    def test_ok_if_optional_is_missing(self):
+        DummyEntity.validate(Node({
+            Node("required"): Node("value"),
+        }))
+
+
+class TestEntityBuild:
+    def test_build_attrs(self):
+        obj = DummyEntity.build(Node({
+            Node("required"): Node(3),
+            Node("optional"): Node(2),
+        }))
+
+        assert isinstance(obj, DummyEntity)
+        assert isinstance(obj.data["required"], DummyAttr)
+        assert isinstance(obj.data["optional"], DummyAttr)
+
+
+class TestEntityAttrs:
+    def test_attrs(self):
+        assert DummyEntity.attrs() == DummyEntity.ATTRS
+
+
+class TestEntityGetattr:
+    def test_get_valid_attr(self):
+        assert Entity(dict(a=2), None).a == 2
+
+    def test_get_invalid_attr(self):
+        with pytest.raises(AttributeError):
+            Entity(dict(a=2), None).b
+
+
+class TestEntityGetitem:
+    def test_get_valid_item(self):
+        assert Entity(dict(a=2), None)["a"] == 2
+
+    def test_get_invalid_item(self):
+        with pytest.raises(KeyError):
+            Entity(dict(a=2), None)["b"]
+
+
+class TestEntityIteration:
+    def test_iteration(self):
+        assert set(Entity(dict(a=1, b=2, c="d"), None)) == {"a", "b", "c"}
+
+
+class TestEntityDig:
+    def test_dig_through_dict(self):
+        obj = Entity({
+            "a": 1,
+            "b": 2,
+            "c": Entity({
+                "d": 6,
+                "e": 7,
+            }, None),
+        }, None)
+
+        assert obj.dig("a") == 1
+        assert obj.dig("c", "d") == 6
+
+    def test_dig_for_missing_key(self):
+        obj = Entity({
+            "a": 1,
+            "b": 2,
+            "c": Entity({
+                "d": 6,
+                "e": 7,
+            }, None),
+        }, None)
+
+        assert obj.dig("k") is None
+        assert obj.dig("c", "k") is None
+
+
+class TestEntityItems:
+    def test_items(self):
+        obj = Entity(dict(a=1, b=2), None)
+
+        assert {("a", 1), ("b", 2)} == set(obj.items())
+
+
+class TestEntityValues:
+    def test_values(self):
+        obj = DummyEntity(dict(a=1, b=2, c=3), None)
+
+        assert {1, 2, 3} == set(obj.values())
+
+
+class TestEntityBare:
+    def test_bare(self):
+        obj = DummyEntity({
+            "required": DummyAttr(3, None),
+            "optional": DummyAttr(2, None),
+        }, None)
+
+        assert obj.bare == dict(required=3, optional=2)
+
+
+class Goodie(TypeEntity):
+    REFERENCE = Reference("path")
+    ATTRS = dict(dummy=Base)
+
+
+class Baddie(TypeEntity):
+    ATTRS = dict(dummy=Base)
+
+
+class TestTypeEntityValidate:
+    def test_valid_data(self, yaml_ast):
+        Goodie.validate(yaml_ast(
+            """
+            derived_from: my_parent_type
+            description: My type description
+            metadata: {}
+            version: 1.2.3.go-4
+            """
+        ))
+
+    def test_missing_derived_from(self, yaml_ast):
+        with pytest.raises(ParseError):
+            Goodie.validate(yaml_ast(
+                """
+                description: My type description
+                metadata: {}
+                version: 1.2.3.go-4
+                """
+            ))
+
+
+class TestTypeEntityAttrs:
+    def test_field_addition(self):
+        assert set(Goodie.attrs().keys()) == {
+            "derived_from", "description", "metadata", "version", "dummy"
+        }
+
+    def test_reference_class_check(self):
+        with pytest.raises(AssertionError):
+            Baddie.attrs()

--- a/tests/opera/parser/tosca/test_integer.py
+++ b/tests/opera/parser/tosca/test_integer.py
@@ -1,0 +1,17 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.integer import Integer
+from opera.parser.yaml.node import Node
+
+
+class TestValidate:
+    def test_with_int_data(self):
+        Integer.validate(Node(1234))
+
+    @pytest.mark.parametrize(
+        "data", ["4",  (), (1, 2, 3), [], ["a", "b"], {}],
+    )
+    def test_with_non_string(self, data):
+        with pytest.raises(ParseError):
+            Integer.validate(Node(data))

--- a/tests/opera/parser/tosca/test_list.py
+++ b/tests/opera/parser/tosca/test_list.py
@@ -1,0 +1,67 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.list import List, ListWrapper
+from opera.parser.tosca.base import Base
+from opera.parser.yaml.node import Node
+
+
+class TestListParse:
+    @pytest.mark.parametrize("data", [1, 3.4, "", "a", (), {}])
+    def test_non_list_data_is_invalid(self, data):
+        with pytest.raises(ParseError, match="list"):
+            List(Base).parse(Node(data))
+
+    def test_empty_list_is_ok(self):
+        assert List(Base).parse(Node([])).bare == []
+
+    def test_list_is_ok(self):
+        obj = List(Base).parse(Node([Node("a"), Node("b")]))
+
+        assert obj.bare == ["a", "b"]
+
+
+class TestListWrapperGetitem:
+    def test_getitem(self):
+        assert ListWrapper(["a", "b"], None)[1] == "b"
+
+    def test_getitem_invalid_index(self):
+        with pytest.raises(IndexError):
+            ListWrapper([], None)[1]
+
+    def test_getitem_invalid_index_type(self):
+        with pytest.raises(TypeError):
+            ListWrapper([], None)["a"]
+
+
+class TestListWrapperIteration:
+    def test_iteration(self):
+        assert tuple(ListWrapper(["a", "b"], None)) == ("a", "b")
+
+class TestListWrapperDig:
+    def test_single_level(self):
+        assert ListWrapper(["a", "b"], None).dig(1) == "b"
+
+    def test_multi_level(self):
+        obj = ListWrapper([
+            ListWrapper(["a", "b"], None),
+            ListWrapper(["c", "d"], None),
+        ], None)
+
+        assert obj.dig(0, 0) == "a"
+        assert obj.dig(0, 1) == "b"
+        assert obj.dig(1, 0) == "c"
+        assert obj.dig(1, 1) == "d"
+
+    def test_bad_index(self):
+        assert ListWrapper([], None).dig(1) is None
+
+    def test_bad_index_type(self):
+        assert ListWrapper([], None).dig("a") is None
+
+
+class TestBare:
+    def test_bare(self):
+        obj = ListWrapper([Base("a", None), Base("b", None)], None)
+
+        assert obj.bare == ["a", "b"]

--- a/tests/opera/parser/tosca/test_map.py
+++ b/tests/opera/parser/tosca/test_map.py
@@ -1,0 +1,100 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.map import Map, MapWrapper, OrderedMap
+from opera.parser.tosca.base import Base
+from opera.parser.yaml.node import Node
+
+
+class TestMapWrapperGetitem:
+    def test_lut_access_for_string_key(self):
+        assert MapWrapper({"k": "v"}, None)["k"] == "v"
+
+    def test_test_non_string_key(self):
+        with pytest.raises(KeyError):
+            assert MapWrapper({Base(1, None): "v" }, None)[1]
+
+
+class TestMapWrapperIteration:
+    def test_iteration(self):
+        data = dict(a="b", c="d")
+        assert list(MapWrapper(data, None)) == list(data)
+
+
+class TestMapWrapperValues:
+    def test_values(self):
+        data = dict(a="b", c="d")
+        assert list(MapWrapper(data, None).values()) == list(data.values())
+
+
+class TestMapWrapperKeys:
+    def test_keys(self):
+        data = dict(a="b", c="d")
+        assert list(MapWrapper(data, None).keys()) == list(data.keys())
+
+
+class TestMapWrapperItems:
+    def test_items(self):
+        data = dict(a="b", c="d")
+        assert list(MapWrapper(data, None).items()) == list(data.items())
+
+
+class TestMapWrapperDig:
+    def test_single_level(self):
+        assert MapWrapper({"k": "v" }, None).dig("k") == "v"
+
+    def test_multi_level(self):
+        obj = MapWrapper({
+            "a": MapWrapper({"b": "c"}, None),
+            "d": MapWrapper({"e": "f"}, None),
+        }, None)
+
+        assert obj.dig("a", "b") == "c"
+        assert obj.dig("d", "e") == "f"
+
+    def test_bad_index(self):
+        assert MapWrapper({}, None).dig("a") is None
+
+    def test_bad_index_type(self):
+        assert MapWrapper({}, None).dig(1) is None
+
+
+class TestMapWrapperBare:
+    def test_bare(self):
+        assert MapWrapper({"a": Base("b", None)}, None).bare == {"a": "b"}
+
+
+class TestMapParse:
+    @pytest.mark.parametrize("data", [1, 3.4, "", "a", (), []])
+    def test_non_dict_data_is_invalid(self, data):
+        with pytest.raises(ParseError, match="map"):
+            Map(Base).parse(Node(data))
+
+    def test_empty_dict_is_ok(self):
+        assert Map(Base).parse(Node({})).bare == {}
+
+    def test_dict_is_ok(self):
+        obj = Map(Base).parse(Node({
+            Node("a"): Node("b"),
+        }))
+
+        assert obj.bare == dict(a="b")
+
+
+class TestOrderedMapParse:
+    @pytest.mark.parametrize("data", [1, 3.4, "", "a", (), {}])
+    def test_non_list_data_is_invalid(self, data):
+        with pytest.raises(ParseError, match="list"):
+            OrderedMap(Base).parse(Node(data))
+
+    def test_empty_list_is_ok(self):
+        assert OrderedMap(Base).parse(Node([])).bare == {}
+
+    def test_dict_is_ok(self):
+        obj = OrderedMap(Base).parse(Node([
+            Node({Node("a"): Node("b")}),
+            Node({Node("c"): Node("d")}),
+        ]))
+        data = [(k, v.data) for k, v in obj.data.items()]
+
+        assert data == [("a", "b"), ("c", "d")]

--- a/tests/opera/parser/tosca/test_reference.py
+++ b/tests/opera/parser/tosca/test_reference.py
@@ -1,0 +1,31 @@
+import pytest
+
+from opera.parser.tosca.reference import Reference
+from opera.parser.yaml.node import Node
+
+
+class TestReferenceInit:
+    @pytest.mark.parametrize("path", [
+        ("single",), ("multi", "path"), ("a", "b", "c", "d"),
+    ])
+    def test_valid_init(self, path):
+        assert Reference(*path).section_path == path
+
+    def test_empty_path(self):
+        with pytest.raises(AssertionError):
+            Reference()
+
+    @pytest.mark.parametrize("path", [
+        (1,), (2.3,), (False,), ((),), ([],), ({},), ("a", 1),
+    ])
+    def test_invalid_path_components(self, path):
+        with pytest.raises(AssertionError):
+            Reference(*path)
+
+
+class TestReferenceParse:
+    @pytest.mark.parametrize("path", [
+        ("single",), ("multi", "path"), ("a", "b", "c", "d"),
+    ])
+    def test_parse(self, path):
+        assert Reference(*path).parse(Node("name")).section_path == path

--- a/tests/opera/parser/tosca/test_string.py
+++ b/tests/opera/parser/tosca/test_string.py
@@ -1,0 +1,17 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.string import String
+from opera.parser.yaml.node import Node
+
+
+class TestValidate:
+    def test_with_string_data(self):
+        String.validate(Node("string"))
+
+    @pytest.mark.parametrize(
+        "data", [4,  (), (1, 2, 3), [], ["a", "b"], {}],
+    )
+    def test_with_non_string(self, data):
+        with pytest.raises(ParseError):
+            String.validate(Node(data))

--- a/tests/opera/parser/tosca/test_version.py
+++ b/tests/opera/parser/tosca/test_version.py
@@ -1,0 +1,22 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.version import Version
+from opera.parser.yaml.node import Node
+
+
+class TestValidate:
+  @pytest.mark.parametrize("version", [
+      "0.0", "0.1", "1.1", "123.456", "1.2.0", "1.2.32", "1.2.3.test",
+      "3.4.5.0rev_a", "6.7.8.a-0", "1.3.6.b-123", "1.2.3.4-5",
+  ])
+  def test_valid_version(self, version):
+      Version.validate(Node(version))
+
+  @pytest.mark.parametrize("version", [
+      "", " ", "garbage", "1", "01.0", "1.02", "1.2.03", "1.2-5", "1-2",
+      "1.2.in-va-lid", "1.2.3-bad", "1.2.3.4-bad",
+  ])
+  def test_invalid_version(self, version):
+      with pytest.raises(ParseError, match="version"):
+          Version.validate(Node(version))

--- a/tests/opera/parser/tosca/test_void.py
+++ b/tests/opera/parser/tosca/test_void.py
@@ -1,0 +1,16 @@
+import pytest
+
+from opera.parser.tosca.void import Void
+from opera.parser.utils.location import Location
+
+
+class TestBare:
+    @pytest.mark.parametrize("data", [1, 2.3, False, "string", None])
+    def test_bare_simple(self, data):
+        assert Void(data, Location("path", 2, 3)).bare == data
+
+    def test_bare_dict(self, yaml_ast):
+        assert Void.parse(yaml_ast("a: b\nc: 4")).bare == dict(a="b", c=4)
+
+    def test_bare_list(self, yaml_ast):
+        assert Void.parse(yaml_ast("[ 1, 2, 3 ]")).bare == [1, 2, 3]

--- a/tests/opera/parser/tosca/v_1_3/test_artifact_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_artifact_definition.py
@@ -1,0 +1,51 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.artifact_definition import ArtifactDefinition
+from opera.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), []])
+    def test_invalid_data(self, data):
+        with pytest.raises(ParseError):
+            ArtifactDefinition.normalize(Node(data))
+
+    def test_string_normalization(self):
+        obj = ArtifactDefinition.normalize(Node("string"))
+
+        assert obj.bare == {
+            "type": "tosca.artifacts.File",
+            "file": "string",
+        }
+
+    def test_dict_normalization(self):
+        node = Node({})
+        obj = ArtifactDefinition.normalize(node)
+
+        assert obj == node
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        ArtifactDefinition.parse(yaml_ast(
+            """
+            description: My arty desc
+            type: my.type
+            file: some/file
+            repository: repo reference
+            deploy_path: another/path
+            checksum: abcsdfkjrkfsdjdbhf
+            checksum_algorithm: SHA256
+            properties:
+              prop: val
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        ArtifactDefinition.parse(yaml_ast(
+            """
+            type: my.type
+            file: some/file
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_artifact_type.py
+++ b/tests/opera/parser/tosca/v_1_3/test_artifact_type.py
@@ -1,0 +1,26 @@
+from opera.parser.tosca.v_1_3.artifact_type import ArtifactType
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        ArtifactType.parse(yaml_ast(
+            """
+            derived_from: artifact_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.2"
+            mime_type: applicaton/json
+            file_ext: [ json, jsn ]
+            properties:
+              prop:
+                type: prop_type
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        ArtifactType.parse(yaml_ast(
+            """
+            derived_from: artifact_type
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_attribute_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_attribute_definition.py
@@ -1,0 +1,20 @@
+from opera.parser.tosca.v_1_3.attribute_definition import AttributeDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        AttributeDefinition.parse(yaml_ast(
+            """
+            type: my_type
+            description: Some desc
+            default: 5
+            status: deprecated
+            key_schema:
+              type: integer
+            entry_schema:
+              type: integer
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        AttributeDefinition.parse(yaml_ast("type: my_type"))

--- a/tests/opera/parser/tosca/v_1_3/test_capability_assignment.py
+++ b/tests/opera/parser/tosca/v_1_3/test_capability_assignment.py
@@ -1,0 +1,17 @@
+from opera.parser.tosca.v_1_3.capability_assignment import CapabilityAssignment
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        CapabilityAssignment.parse(yaml_ast(
+            """
+            properties:
+              prop: value
+            attributes:
+              attr: value
+            occurrences: [ 0, UNBOUNDED ]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        CapabilityAssignment.parse(yaml_ast("{}"))

--- a/tests/opera/parser/tosca/v_1_3/test_capability_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_capability_definition.py
@@ -1,0 +1,22 @@
+from opera.parser.tosca.v_1_3.capability_definition import CapabilityDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        CapabilityDefinition.parse(yaml_ast(
+            """
+            type: cap_type_name
+            description: Some text
+            properties: {}
+            attributes: {}
+            valid_source_types: []
+            occurrences: [ 4, UNBOUNDED ]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        CapabilityDefinition.parse(yaml_ast(
+            """
+            type: cap_type_name
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_capability_type.py
+++ b/tests/opera/parser/tosca/v_1_3/test_capability_type.py
@@ -1,0 +1,29 @@
+from opera.parser.tosca.v_1_3.capability_type import CapabilityType
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        CapabilityType.parse(yaml_ast(
+            """
+            derived_from: cap_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.2"
+            properties:
+              prop:
+                type: list
+            attributes:
+              attr:
+                type: string
+            valid_source_types:
+              - my_type
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        CapabilityType.parse(yaml_ast(
+            """
+            derived_from: cap_type
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_constraint_clause.py
+++ b/tests/opera/parser/tosca/v_1_3/test_constraint_clause.py
@@ -1,0 +1,17 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.constraint_clause import ConstraintClause
+
+
+class TestValidate:
+    def test_valid_clause(self, yaml_ast):
+        ConstraintClause.validate(yaml_ast("equal: 3"))
+
+    def test_invalid_clause(self, yaml_ast):
+        with pytest.raises(ParseError):
+            ConstraintClause.validate(yaml_ast("bad_operator: must fail"))
+
+class TestParse:
+    def test_parse(self, yaml_ast):
+        ConstraintClause.parse(yaml_ast("in_range: [ 1, 2 ]"))

--- a/tests/opera/parser/tosca/v_1_3/test_credential.py
+++ b/tests/opera/parser/tosca/v_1_3/test_credential.py
@@ -1,0 +1,23 @@
+from opera.parser.tosca.v_1_3.credential import Credential
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        Credential.parse(yaml_ast(
+            """
+            protocol: tcp
+            token_type: password
+            token: my_password
+            keys:
+              first: key
+              yet: another key
+            user: my_user
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        Credential.parse(yaml_ast(
+            """
+            token: my_password
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_data_type.py
+++ b/tests/opera/parser/tosca/v_1_3/test_data_type.py
@@ -1,0 +1,41 @@
+import pytest
+
+from opera.parser.tosca.v_1_3.data_type import DataType
+from opera.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), "string"])
+    def test_ignores_non_dict_data(self, data):
+        node = Node(data)
+
+        assert DataType.normalize(node) == node
+
+    def test_ignores_dict_data_with_derived_from_key(self):
+        node = Node({Node("derived_from"): Node("integer")})
+
+        assert DataType.normalize(node) == node
+
+    def test_updates_dict_data_with_derived_from_key(self):
+        assert DataType.normalize(Node({})).bare == {"derived_from": "None"}
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        DataType.parse(yaml_ast(
+            """
+            derived_from: data_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.4"
+            constraints:
+              - in_range: [ 1, 6 ]
+            properties:
+              prop:
+                type: map
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        DataType.parse(yaml_ast("{}"))

--- a/tests/opera/parser/tosca/v_1_3/test_group_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_group_definition.py
@@ -1,0 +1,24 @@
+from opera.parser.tosca.v_1_3.group_definition import GroupDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        GroupDefinition.parse(yaml_ast(
+            """
+            type: node.type
+            description: Text
+            metadata: {}
+            properties: {}
+            members:
+              - node_template_1
+              - node_template_2
+              - node_template_3
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        GroupDefinition.parse(yaml_ast(
+            """
+            type: group.type
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_group_type.py
+++ b/tests/opera/parser/tosca/v_1_3/test_group_type.py
@@ -1,0 +1,24 @@
+from opera.parser.tosca.v_1_3.group_type import GroupType
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        GroupType.parse(yaml_ast(
+            """
+            derived_from: group_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.2"
+            attributes: {}
+            properties: {}
+            members: [node_type_a, node_type_b, node_type_c]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        GroupType.parse(yaml_ast(
+            """
+            derived_from: group_type
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_import_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_import_definition.py
@@ -1,0 +1,38 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.import_definition import ImportDefinition
+from opera.parser.yaml.node import Node
+
+
+class TestNormalizeDefinition:
+    def test_noop_for_dicts(self):
+        node = Node({})
+        assert ImportDefinition.normalize(node) == node
+
+    def test_string_normalization(self):
+        assert ImportDefinition.normalize(Node("a")).bare == {"file": "a"}
+
+    @pytest.mark.parametrize("data", [123, 1.4, []])
+    def test_failed_normalization(self, data):
+        with pytest.raises(ParseError, match="string or dict"):
+            ImportDefinition.normalize(Node(data))
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        ImportDefinition.parse(yaml_ast(
+            """
+            file: my/file
+            repository: my_repo
+            namespace_prefix: prefix
+            namespace_uri: some_uri
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        ImportDefinition.parse(yaml_ast(
+            """
+            file: my/file
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_interface_definition_for_template.py
+++ b/tests/opera/parser/tosca/v_1_3/test_interface_definition_for_template.py
@@ -1,0 +1,21 @@
+from opera.parser.tosca.v_1_3.interface_definition_for_template import (
+    InterfaceDefinitionForTemplate,
+)
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        InterfaceDefinitionForTemplate.parse(yaml_ast(
+            """
+            inputs:
+              in: put
+            operations:
+              op: artifact
+            notifications:
+              my_notification:
+                description: Notification description
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        InterfaceDefinitionForTemplate.parse(yaml_ast("{}"))

--- a/tests/opera/parser/tosca/v_1_3/test_interface_definition_for_type.py
+++ b/tests/opera/parser/tosca/v_1_3/test_interface_definition_for_type.py
@@ -1,0 +1,17 @@
+from opera.parser.tosca.v_1_3.interface_definition_for_type import (
+    InterfaceDefinitionForType,
+)
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        InterfaceDefinitionForType.parse(yaml_ast(
+            """
+            inputs: {}
+            operations: {}
+            notifications: {}
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        InterfaceDefinitionForType.parse(yaml_ast("{}"))

--- a/tests/opera/parser/tosca/v_1_3/test_interface_type.py
+++ b/tests/opera/parser/tosca/v_1_3/test_interface_type.py
@@ -1,0 +1,26 @@
+from opera.parser.tosca.v_1_3.interface_type import InterfaceType
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        InterfaceType.parse(yaml_ast(
+            """
+            derived_from: interface_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.2"
+            inputs:
+              in:
+                type: float
+            operations: {}
+            notifications: {}
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        InterfaceType.parse(yaml_ast(
+            """
+            derived_from: interface_type
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_node_filter_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_node_filter_definition.py
@@ -1,0 +1,17 @@
+from opera.parser.tosca.v_1_3.node_filter_definition import (
+    NodeFilterDefinition,
+)
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        NodeFilterDefinition.parse(yaml_ast(
+            """
+            properties:
+              - num_cpus: { in_range: [ 3, 6 ] }
+            capabilities: []
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        NodeFilterDefinition.parse(yaml_ast("{}"))

--- a/tests/opera/parser/tosca/v_1_3/test_node_template.py
+++ b/tests/opera/parser/tosca/v_1_3/test_node_template.py
@@ -1,0 +1,28 @@
+from opera.parser.tosca.v_1_3.node_template import NodeTemplate
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        NodeTemplate.parse(yaml_ast(
+            """
+            type: node.type
+            description: Text
+            metadata: {}
+            directives: []
+            properties: {}
+            attributes: {}
+            requirements: []
+            capabilities: {}
+            interfaces: {}
+            artifacts: {}
+            node_filter: {}
+            copy: template_name
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        NodeTemplate.parse(yaml_ast(
+            """
+            type: node.type
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_node_type.py
+++ b/tests/opera/parser/tosca/v_1_3/test_node_type.py
@@ -1,0 +1,29 @@
+from opera.parser.tosca.v_1_3.node_type import NodeType
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        NodeType.parse(yaml_ast(
+            """
+            derived_from: node_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.2"
+            attributes: {}
+            properties: {}
+            requirements:
+              - first: requirement_cap_name
+              - second:
+                  capability: type_name
+            interfaces: {}
+            artifacts: {}
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        NodeType.parse(yaml_ast(
+            """
+            derived_from: node_type
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_notification_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_notification_definition.py
@@ -1,0 +1,18 @@
+from opera.parser.tosca.v_1_3.notification_definition import (
+    NotificationDefinition,
+)
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        NotificationDefinition.parse(yaml_ast(
+            """
+            description: Bla bla bla
+            implementation: path/to/artifact
+            outputs:
+              data: [ SELF, attribute ]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        NotificationDefinition.parse(yaml_ast("{}"))

--- a/tests/opera/parser/tosca/v_1_3/test_notification_implementation_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_notification_implementation_definition.py
@@ -1,0 +1,39 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.notification_implementation_definition import (
+    NotificationImplementationDefinition,
+)
+from opera.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), []])
+    def test_invalid_data(self, data):
+        with pytest.raises(ParseError):
+            NotificationImplementationDefinition.normalize(Node(data))
+
+    def test_string_normalization(self):
+        obj = NotificationImplementationDefinition.normalize(Node("string"))
+
+        assert obj.bare == {"primary": "string"}
+
+    def test_dict_normalization(self):
+        node = Node({})
+        obj = NotificationImplementationDefinition.normalize(node)
+
+        assert obj == node
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        NotificationImplementationDefinition.parse(yaml_ast(
+            """
+            primary: first
+            dependencies:
+              - second
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        NotificationImplementationDefinition.parse(yaml_ast("first"))

--- a/tests/opera/parser/tosca/v_1_3/test_operation_definition_for_template.py
+++ b/tests/opera/parser/tosca/v_1_3/test_operation_definition_for_template.py
@@ -1,0 +1,42 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.operation_definition_for_template import (
+    OperationDefinitionForTemplate,
+)
+from opera.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), []])
+    def test_invalid_data(self, data):
+        with pytest.raises(ParseError):
+            OperationDefinitionForTemplate.normalize(Node(data))
+
+    def test_string_normalization(self):
+        obj = OperationDefinitionForTemplate.normalize(Node("string"))
+
+        assert obj.bare == {"implementation": "string"}
+
+    def test_dict_normalization(self):
+        node = Node({})
+        obj = OperationDefinitionForTemplate.normalize(node)
+
+        assert obj == node
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        OperationDefinitionForTemplate.parse(yaml_ast(
+            """
+            description: Even more text
+            implementation: path/to/artifact
+            inputs:
+              my_input: value
+            outputs:
+              my_output: [ SELF, attribute_name ]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        OperationDefinitionForTemplate.parse(yaml_ast("{}"))

--- a/tests/opera/parser/tosca/v_1_3/test_operation_definition_for_type.py
+++ b/tests/opera/parser/tosca/v_1_3/test_operation_definition_for_type.py
@@ -1,0 +1,43 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.operation_definition_for_type import (
+    OperationDefinitionForType,
+)
+from opera.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), []])
+    def test_invalid_data(self, data):
+        with pytest.raises(ParseError):
+            OperationDefinitionForType.normalize(Node(data))
+
+    def test_string_normalization(self):
+        obj = OperationDefinitionForType.normalize(Node("string"))
+
+        assert obj.bare == {"implementation": "string"}
+
+    def test_dict_normalization(self):
+        node = Node({})
+        obj = OperationDefinitionForType.normalize(node)
+
+        assert obj == node
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        OperationDefinitionForType.parse(yaml_ast(
+            """
+            description: Some description
+            implementation: bla
+            inputs:
+              input:
+                type: string
+            outputs:
+              output: [1, 2, 3, 4, 5]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        OperationDefinitionForType.parse(yaml_ast("{}"))

--- a/tests/opera/parser/tosca/v_1_3/test_operation_host.py
+++ b/tests/opera/parser/tosca/v_1_3/test_operation_host.py
@@ -1,0 +1,22 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.operation_host import OperationHost
+from opera.parser.yaml.node import Node
+
+
+class TestValidate:
+    @pytest.mark.parametrize(
+        "version", ["SELF", "HOST", "SOURCE", "TARGET", "ORCHESTRATOR"],
+    )
+    def test_valid_tosca_versions(self, version):
+        OperationHost.validate(Node(version))
+
+    @pytest.mark.parametrize(
+        "version", [
+            "", "  ", "a", "tosca_simple_yaml_1_3", 123, "abc", {}, [],
+        ],
+    )
+    def test_invalid_tosca_versions(self, version):
+        with pytest.raises(ParseError):
+            OperationHost.validate(Node(version))

--- a/tests/opera/parser/tosca/v_1_3/test_operation_implementation_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_operation_implementation_definition.py
@@ -1,0 +1,42 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.operation_implementation_definition import (
+    OperationImplementationDefinition,
+)
+from opera.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), []])
+    def test_invalid_data(self, data):
+        with pytest.raises(ParseError):
+            OperationImplementationDefinition.normalize(Node(data))
+
+    def test_string_normalization(self):
+        obj = OperationImplementationDefinition.normalize(Node("string"))
+
+        assert obj.bare == {"primary": "string"}
+
+    def test_dict_normalization(self):
+        node = Node({})
+        obj = OperationImplementationDefinition.normalize(node)
+
+        assert obj == node
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        OperationImplementationDefinition.parse(yaml_ast(
+            """
+            primary: artifact
+            dependencies:
+              - first
+              - second
+            timeout: 4
+            operation_host: ORCHESTRATOR
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        OperationImplementationDefinition.parse(yaml_ast("{}"))

--- a/tests/opera/parser/tosca/v_1_3/test_parameter_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_parameter_definition.py
@@ -1,0 +1,25 @@
+from opera.parser.tosca.v_1_3.parameter_definition import ParameterDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        ParameterDefinition.parse(yaml_ast(
+            """
+            type: data_type_name
+            description: My text
+            required: true
+            default: 567
+            status: supported
+            constraints: []
+            key_schema:
+              type: string
+            entry_schema:
+              type: timestamp
+            external_schema: schema
+            metadata: {}
+            value: 987
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        ParameterDefinition.parse(yaml_ast("{}"))

--- a/tests/opera/parser/tosca/v_1_3/test_policy_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_policy_definition.py
@@ -1,0 +1,21 @@
+from opera.parser.tosca.v_1_3.policy_definition import PolicyDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        PolicyDefinition.parse(yaml_ast(
+            """
+            type: policy.type
+            description: Some muttering
+            metadata: {}
+            properties:
+              prop: 6.7
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        PolicyDefinition.parse(yaml_ast(
+            """
+            type: policy.type
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_policy_type.py
+++ b/tests/opera/parser/tosca/v_1_3/test_policy_type.py
@@ -1,0 +1,22 @@
+from opera.parser.tosca.v_1_3.policy_type import PolicyType
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        PolicyType.parse(yaml_ast(
+            """
+            derived_from: policy_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.2"
+            properties: {}
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        PolicyType.parse(yaml_ast(
+            """
+            derived_from: policy_type
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_property_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_property_definition.py
@@ -1,0 +1,30 @@
+import pytest
+
+from opera.parser.tosca.v_1_3.property_definition import PropertyDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        PropertyDefinition.parse(yaml_ast(
+            """
+            type: map
+            description: My description
+            required: false
+            default: { a: 3 }
+            status: supported
+            constraints: []
+            key_schema:
+              type: string
+            entry_schema:
+              type: integer
+            external_schema: some schema
+            metadata: {}
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        PropertyDefinition.parse(yaml_ast(
+            """
+            type: map
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_range.py
+++ b/tests/opera/parser/tosca/v_1_3/test_range.py
@@ -1,0 +1,36 @@
+import math
+
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.range import Range
+from opera.parser.yaml.node import Node
+
+
+class TestValidate:
+    @pytest.mark.parametrize("data", [
+        "[1, 2]", "[3, UNBOUNDED]", "- 3\n- 6",
+    ])
+    def test_with_valid_data(self, data, yaml_ast):
+        Range.validate(yaml_ast(data))
+
+    @pytest.mark.parametrize("data", [
+        "abc", "4," "{}", "3.4", "false", "null",         # Invalid types
+        "[]", "[1]", "[1, 2, 3]", "[1, 2, 3, 4]",         # Invalid cardinality
+        "[a, 1]", "[2.3, 1]", "[false, 1]", "[null, 1]",  # Invalid lo type
+        "[0, 1.3]", "[0, true]", "[0, null]", "[0, {}]",  # Invalid hi type
+        "[0, a]", "[0, \"\"]", "[0, BAD]",                # Invalid hi string
+        "[5, 2]", "[-3, -6]", "[4, -3]",                  # lo > hi
+    ])
+    def test_invalid_data(self, data, yaml_ast):
+        with pytest.raises(ParseError):
+            Range.validate(yaml_ast(data))
+
+
+class TestBuild:
+    @pytest.mark.parametrize("input,output", [
+        ("[1, 2]", (1, 2)), ("[-4, 5]", (-4, 5)),
+        ("[0, UNBOUNDED]", (0, math.inf)),
+    ])
+    def test_construction(self, input, output, yaml_ast):
+        assert Range.build(yaml_ast(input)).data == output

--- a/tests/opera/parser/tosca/v_1_3/test_relationship_template.py
+++ b/tests/opera/parser/tosca/v_1_3/test_relationship_template.py
@@ -1,0 +1,28 @@
+from opera.parser.tosca.v_1_3.relationship_template import RelationshipTemplate
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        RelationshipTemplate.parse(yaml_ast(
+            """
+            type: rel.type
+            description: Some muttering
+            metadata: {}
+            properties:
+              prop: 4
+            attributes:
+              attr: 6
+            interfaces:
+              Standard:
+                operations:
+                  create: path/to/playbook.yaml
+            copy: other_template_name
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        RelationshipTemplate.parse(yaml_ast(
+            """
+            type: rel.type
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_relationship_type.py
+++ b/tests/opera/parser/tosca/v_1_3/test_relationship_type.py
@@ -1,0 +1,25 @@
+from opera.parser.tosca.v_1_3.relationship_type import RelationshipType
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        RelationshipType.parse(yaml_ast(
+            """
+            derived_from: relationship_type
+            description: My desc
+            metadata:
+              key: value
+            version: "1.2"
+            properties: {}
+            attributes: {}
+            interfaces: {}
+            valid_target_types: [ a, b, c ]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        RelationshipType.parse(yaml_ast(
+            """
+            derived_from: relationship_type
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_repository_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_repository_definition.py
@@ -1,0 +1,39 @@
+import pytest
+
+from opera.parser.yaml.node import Node
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.repository_definition import RepositoryDefinition
+
+
+class TestNormalize:
+    def test_noop_for_dicts(self):
+        node = Node({})
+        assert RepositoryDefinition.normalize(node) == node
+
+    def test_string_normalization(self):
+        assert RepositoryDefinition.normalize(Node("a")).bare == {"url": "a"}
+
+    @pytest.mark.parametrize("data", [123, 1.4, []])
+    def test_failed_normalization(self, data):
+        with pytest.raises(ParseError, match="string or dict"):
+            RepositoryDefinition.normalize(Node(data))
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        RepositoryDefinition.parse(yaml_ast(
+            """
+            description: My description
+            url: https://repo.name
+            credential:
+              token: my_pass
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        RepositoryDefinition.parse(yaml_ast(
+            """
+            url: https://repo.name
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_requirement_assignment.py
+++ b/tests/opera/parser/tosca/v_1_3/test_requirement_assignment.py
@@ -1,0 +1,46 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.requirement_assignment import (
+    RequirementAssignment,
+)
+from opera.parser.yaml.node import Node
+
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), []])
+    def test_invalid_data(self, data):
+        with pytest.raises(ParseError):
+            RequirementAssignment.normalize(Node(data))
+
+    def test_string_normalization(self):
+        obj = RequirementAssignment.normalize(Node("string"))
+
+        assert obj.bare == {"node": "string"}
+
+    def test_dict_normalization(self):
+        node = Node({})
+        obj = RequirementAssignment.normalize(node)
+
+        assert obj == node
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        RequirementAssignment.parse(yaml_ast(
+            """
+            capability: my_cap
+            node: some_node_template
+            relationship: some_relationship_template
+            node_filter: {}
+            occurrences: [ 2, 3 ]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        RequirementAssignment.parse(yaml_ast(
+            """
+            some_node_template
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_requirement_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_requirement_definition.py
@@ -1,0 +1,44 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.requirement_definition import (
+    RequirementDefinition,
+)
+from opera.parser.yaml.node import Node
+
+
+class TestNormalize:
+    @pytest.mark.parametrize("data", [1, 2.3, True, (), []])
+    def test_invalid_data(self, data):
+        with pytest.raises(ParseError):
+            RequirementDefinition.normalize(Node(data))
+
+    def test_string_normalization(self):
+        obj = RequirementDefinition.normalize(Node("string"))
+
+        assert obj.bare == {"capability": "string"}
+
+    def test_dict_normalization(self):
+        node = Node({})
+        obj = RequirementDefinition.normalize(node)
+
+        assert obj == node
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        RequirementDefinition.parse(yaml_ast(
+            """
+            capability: my_cap_type
+            node: my_node_type
+            relationship: my_rel_type
+            occurrences: [ 2, 5 ]
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        RequirementDefinition.parse(yaml_ast(
+            """
+            capability: my_cap_type
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_schema_definition.py
+++ b/tests/opera/parser/tosca/v_1_3/test_schema_definition.py
@@ -1,0 +1,21 @@
+import pytest
+
+from opera.parser.tosca.v_1_3.schema_definition import SchemaDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        SchemaDefinition.parse(yaml_ast(
+            """
+            type: my_type
+            description: My description
+            constraints: []
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        SchemaDefinition.parse(yaml_ast(
+            """
+            type: my_type
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_service_template.py
+++ b/tests/opera/parser/tosca/v_1_3/test_service_template.py
@@ -1,0 +1,58 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.service_template import ServiceTemplate
+from opera.parser.yaml.node import Node
+
+
+class TestNormalizeDefinition:
+    def test_noop_for_dicts_with_no_dsl_definitions(self):
+        assert ServiceTemplate.normalize(Node({})).bare == {}
+
+    def test_dsl_definitions_removal(self):
+        assert ServiceTemplate.normalize(Node({
+            Node("dsl_definitions"): "data",
+        })).bare == {}
+
+    @pytest.mark.parametrize("data", [123, 1.4, []])
+    def test_failure_with_non_dict_data(self, data):
+        with pytest.raises(ParseError):
+            ServiceTemplate.normalize(Node(data))
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        ServiceTemplate.parse(yaml_ast(
+            """
+            tosca_definitions_version: tosca_simple_yaml_1_3
+            namespace: some.namespace
+            metadata: {}
+            description: Text here
+            dsl_definitions:
+              arbitrary_data: can
+              be: here
+              since:
+                - it
+                - is
+                - stripped: from
+                  the: doc
+            repositories: {}
+            imports: []
+            artifact_types: {}
+            data_types: {}
+            capability_types: {}
+            interface_types: {}
+            relationship_types: {}
+            node_types: {}
+            group_types: {}
+            policy_types: {}
+            topology_template: {}
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        ServiceTemplate.parse(yaml_ast(
+            """
+            tosca_definitions_version: tosca_simple_yaml_1_3
+            """
+        ))

--- a/tests/opera/parser/tosca/v_1_3/test_status.py
+++ b/tests/opera/parser/tosca/v_1_3/test_status.py
@@ -1,0 +1,20 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.status import Status
+from opera.parser.yaml.node import Node
+
+
+class TestValidate:
+    @pytest.mark.parametrize(
+        "status", ["supported", "unsupported", "experimental", "deprecated"],
+    )
+    def test_valid_status(self, status):
+        Status.validate(Node(status))
+
+    @pytest.mark.parametrize(
+        "status", ["some", "random", "stuff", 1, 2, [], {}, (), 1.2, False],
+    )
+    def test_invalid_status(self, status):
+        with pytest.raises(ParseError):
+            Status.validate(Node(status))

--- a/tests/opera/parser/tosca/v_1_3/test_topology_template.py
+++ b/tests/opera/parser/tosca/v_1_3/test_topology_template.py
@@ -1,0 +1,32 @@
+from opera.parser.tosca.v_1_3.topology_template import TopologyTemplate
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        TopologyTemplate.parse(yaml_ast(
+            """
+            description: Topology description
+            inputs:
+              my_input:
+                type: float
+                value: 14.3
+            node_templates:
+              my_node_template:
+                type: node.type
+            relationship_templates:
+              my_rel_template:
+                type: rel.type
+            groups:
+              my_group:
+                type: group.type
+            policies:
+              my_policy:
+                type: policy.type
+            outputs:
+              my_output:
+                type: string
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        TopologyTemplate.parse(yaml_ast("{}"))

--- a/tests/opera/parser/tosca/v_1_3/test_tosca_definitions_version.py
+++ b/tests/opera/parser/tosca/v_1_3/test_tosca_definitions_version.py
@@ -1,0 +1,24 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.tosca_definitions_version import (
+    ToscaDefinitionsVersion,
+)
+from opera.parser.yaml.node import Node
+
+
+class TestValidate:
+    def test_valid_tosca_versions(self):
+        ToscaDefinitionsVersion.validate(Node("tosca_simple_yaml_1_3"))
+
+    @pytest.mark.parametrize(
+        "version", [
+            "", "  ", "a", "tosca_simple_yaml_1_4", 123, "abc", {}, [],
+            "tosca_simple_yaml_1_4", "tosca_simple_yaml_2", "tosca_yaml_1_2",
+            "tosca_simple_yaml_1_0", "tosca_simple_yaml_1_1",
+            "tosca_simple_yaml_1_2",
+        ],
+    )
+    def test_invalid_tosca_versions(self, version):
+        with pytest.raises(ParseError):
+            ToscaDefinitionsVersion.validate(Node(version))

--- a/tests/opera/parser/yaml/test_node.py
+++ b/tests/opera/parser/yaml/test_node.py
@@ -1,59 +1,71 @@
+from opera.parser.utils.location import Location
 from opera.parser.yaml.node import Node
 
 
 class TestInit:
     def test_constructor(self):
-        node = Node("value", "name", 1, 2)
+        node = Node("value", Location("name", 1, 2))
 
         assert node.value == "value"
         assert node.loc.stream_name == "name"
         assert node.loc.line == 1
         assert node.loc.column == 2
 
+    def test_empty_loc_constructor(self):
+        node = Node("value")
+
+        assert node.value == "value"
+        assert node.loc.stream_name == ""
+        assert node.loc.line == 0
+        assert node.loc.column == 0
+
 
 class TestDump:
     def test_null_dump(self):
-        node = Node(None, "s", 1, 1)
+        node = Node(None, Location("s", 1, 1))
 
         assert node.dump() == "NoneType(s:1:1)(None)"
 
     def test_bool_dump(self):
-        node = Node(True, "s", 1, 1)
+        node = Node(True, Location("s", 1, 1))
 
         assert node.dump() == "bool(s:1:1)(True)"
 
     def test_int_dump(self):
-        node = Node(123, "s", 1, 1)
+        node = Node(123, Location("s", 1, 1))
 
         assert node.dump() == "int(s:1:1)(123)"
 
     def test_sfloat_dump(self):
-        node = Node(123.456, "s", 1, 1)
+        node = Node(123.456, Location("s", 1, 1))
 
         assert node.dump() == "float(s:1:1)(123.456)"
 
     def test_str_dump(self):
-        node = Node("string", "s", 1, 1)
+        node = Node("string", Location("s", 1, 1))
 
         assert node.dump() == "str(s:1:1)(string)"
 
     def test_scalar_ignores_padding(self):
-        node = Node("string", "s", 1, 1)
+        node = Node("string", Location("s", 1, 1))
 
         assert node.dump("    ") == "str(s:1:1)(string)"
 
     def test_seq_dump(self):
-        node = Node([Node(1, "s", 1, 1), Node("a", "k", 2, 3)], "u", 5, 6)
+        node = Node([Node(1), Node("a")])
 
         assert node.dump() == (
-            "list(u:5:6)[\n"
-            "  int(s:1:1)(1),\n"
-            "  str(k:2:3)(a)\n"
+            "list(:0:0)[\n"
+            "  int(:0:0)(1),\n"
+            "  str(:0:0)(a)\n"
             "]"
         )
 
     def test_seq_dump_padded(self):
-        node = Node([Node(1, "s", 1, 1), Node("a", "k", 2, 3)], "u", 5, 6)
+        node = Node([
+            Node(1, Location("s", 1, 1)),
+            Node("a", Location("k", 2, 3)),
+        ], Location("u", 5, 6))
 
         assert node.dump("   ") == (
             "list(u:5:6)[\n"
@@ -63,32 +75,33 @@ class TestDump:
         )
 
     def test_map_dump(self):
-        node = Node({Node(1, "s", 1, 1): Node("a", "k", 2, 3)}, "u", 5, 6)
+        node = Node({Node(1): Node("a")})
 
         assert node.dump() == (
-            "dict(u:5:6){\n"
-            "  int(s:1:1)(1): str(k:2:3)(a)\n"
+            "dict(:0:0){\n"
+            "  int(:0:0)(1): str(:0:0)(a)\n"
             "}"
         )
 
     def test_map_dump_padded(self):
-        node = Node({Node(1, "s", 1, 1): Node("a", "k", 2, 3)}, "u", 5, 6)
+        node = Node({Node(1): Node("a")})
 
         assert node.dump("      ") == (
-            "dict(u:5:6){\n"
-            "        int(s:1:1)(1): str(k:2:3)(a)\n"
+            "dict(:0:0){\n"
+            "        int(:0:0)(1): str(:0:0)(a)\n"
             "      }"
         )
 
     def test_dump_nested(self):
-        child = Node([Node(1, "a", 1, 2), Node("a", "b", 3, 4)], "c", 5, 6)
-        node = Node({Node(True, "d", 7, 8): child}, "e", 9, 0)
+        node = Node({
+            Node(True): Node([Node(1), Node("a")])
+        })
 
         assert node.dump() == (
-            "dict(e:9:0){\n"
-            "  bool(d:7:8)(True): list(c:5:6)[\n"
-            "    int(a:1:2)(1),\n"
-            "    str(b:3:4)(a)\n"
+            "dict(:0:0){\n"
+            "  bool(:0:0)(True): list(:0:0)[\n"
+            "    int(:0:0)(1),\n"
+            "    str(:0:0)(a)\n"
             "  ]\n"
             "}"
         )
@@ -96,25 +109,22 @@ class TestDump:
 
 class TestBare:
     def test_bare_scalar(self):
-        assert Node(1, "a", 2, 3).bare == 1
+        assert Node(1).bare == 1
 
     def test_bare_seq(self):
-        node = Node([Node(1, "s", 1, 1), Node("a", "k", 2, 3)], "u", 5, 6)
-
-        assert node.bare == [1, "a"]
+        assert Node([Node(1), Node("a")]).bare == [1, "a"]
 
     def test_bare_map(self):
-        node = Node({Node(1, "s", 1, 1): Node("a", "k", 2, 3)}, "u", 5, 6)
-
-        assert node.bare == {1: "a"}
+        assert Node({Node(1): Node("a")}).bare == {1: "a"}
 
     def test_base_nested(self):
-        child = Node([Node(1, "s", 1, 1), Node("a", "k", 2, 3)], "u", 5, 6)
-        node = Node({Node(1, "s", 1, 1): child}, "u", 5, 6)
+        node = Node({
+            Node(1): Node([Node(1), Node("a")]),
+        })
 
         assert node.bare == {1: [1, "a"]}
 
 
 class TestStr:
     def test_str(self):
-        assert str(Node(0, "a", 1, 2)) == "int(a:1:2)(0)"
+        assert str(Node(0, Location("a", 1, 2))) == "int(a:1:2)(0)"


### PR DESCRIPTION
Changes in this pull request allow opera to parse almost any valid TOSCA 1.3 document. There are a few pieces still missing (like substitution mappings), but they will be added if we decide to add support for this to the opera.