### PR TITLE
Make ouputs optional.

### DIFF
--- a/src/opera/parser/tosca/v_1_3/topology_template.py
+++ b/src/opera/parser/tosca/v_1_3/topology_template.py
@@ -62,5 +62,5 @@ class TopologyTemplate(Entity):
                 value=definition.get_value(
                     definition.get_value_type(service_ast),
                 ),
-            ) for name, definition in self.outputs.items()
+            ) for name, definition in self.get("outputs", {}).items()
         }


### PR DESCRIPTION
In the current version (0.5.3) of xOpera, outputs are mandatory. I would suggest a quick fix to make them optional. @tadeboro could you take a look?