### PR TITLE
Properly handle nested root template

### DIFF
--- a/src/opera/parser/tosca/__init__.py
+++ b/src/opera/parser/tosca/__init__.py
@@ -24,7 +24,7 @@ def load(base_path, template_name):
 
     stdlib_yaml = stdlib.load(tosca_version)
     service = parser.parse(stdlib_yaml, base_path, PurePath("STDLIB"))
-    service.merge(parser.parse(input_yaml, base_path, PurePath()))
+    service.merge(parser.parse(input_yaml, base_path, template_name.parent))
     service.visit("resolve_path", base_path)
     service.visit("resolve_reference", service)
 


### PR DESCRIPTION
CSAR archives that contain TOSCA metadata can have a root service template at any depth in the folder hierarchy. Up until now, opera assumed that the service template that contains the topology will be always present at the root of the CSAR, which messed-up the import resolution.

To resolve this, we taught opera about the relative path to the root service template.

Fixes #25