### PR TITLE
Bring back CSAR service template validation

### DIFF
--- a/src/opera/commands/__init__.py
+++ b/src/opera/commands/__init__.py
@@ -2,4 +2,5 @@ from opera.commands import (
     outputs,
     deploy,
     undeploy,
+    validate
 )

--- a/src/opera/commands/validate.py
+++ b/src/opera/commands/validate.py
@@ -1,0 +1,40 @@
+import argparse
+from pathlib import Path, PurePath
+
+import yaml
+from opera.error import ParseError
+from opera.parser import tosca
+
+
+def add_parser(subparsers):
+    parser = subparsers.add_parser(
+        "validate",
+        help="Validate service template from CSAR"
+    )
+    parser.add_argument(
+        "--inputs", "-i", type=argparse.FileType("r"),
+        help="YAML file with inputs",
+    )
+    parser.add_argument("csar",
+                        type=argparse.FileType("r"),
+                        help="Cloud service archive file")
+    parser.set_defaults(func=validate)
+
+
+def validate(args):
+    print("Validating service template ...")
+
+    try:
+        inputs = yaml.safe_load(args.inputs) if args.inputs else {}
+    except Exception as e:
+        print("Invalid inputs: {}".format(e))
+        return 1
+
+    try:
+        ast = tosca.load(Path.cwd(), PurePath(args.csar.name))
+        ast.get_template(inputs)
+        print("Done.")
+        return 0
+    except ParseError as e:
+        print("{}: {}".format(e.loc, e))
+        return 1


### PR DESCRIPTION
In this commit we bring back the ability to validate TOSCA template from CSAR using `opera validate` command that was removed with 0.5.0 version.

Changes also contain inputs so that validation could also be performed with -i (--inputs) option where the inputs for the service template are checked.