### PR TITLE
Remove the root __init__.py to enable PEP420.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
 [options]
 package_dir =
   = src
-packages = find:
+packages = find_namespace:
 zip_safe = True
 include_package_data = True
 setup_requires =


### PR DESCRIPTION
[PEP420](https://www.python.org/dev/peps/pep-0420/) are Implicit Namespace Packages. Without breaking anything (assuming Python >= 3.3), it allows the `opera` namespace (previously a package) to be extended in other source trees.

Example.

* Create a new project that depends on xopera-opera - `pip install opera==0.5.5`.
* `mkdir -p opera/extension/`
* `touch opera/extension/__init__.py`
* `echo "import opera.commands" > opera/extension/thing.py`
* `python3 -m opera.extension.thing`
* Result
  * without PEP420 in this repository: `Error while finding module specification for 'opera.extension.thing' (ModuleNotFoundError: No module named 'opera.extension')`
  * with PEP420 in this repository: EOF

To be specific about my needs, I would like to `import opera` in the xOpera API package we're developing and _also_ use `opera.api` as a package to contain the API implementation.

I've tested `pip install -e . && opera` to work with the file missing.

cc @cankarm 