### PR TITLE
Add duplicate imports management

### DIFF
--- a/src/opera/parser/tosca/__init__.py
+++ b/src/opera/parser/tosca/__init__.py
@@ -23,8 +23,12 @@ def load(base_path, template_name):
     parser = _get_parser(tosca_version)
 
     stdlib_yaml = stdlib.load(tosca_version)
-    service = parser.parse(stdlib_yaml, base_path, PurePath("STDLIB"))
-    service.merge(parser.parse(input_yaml, base_path, template_name.parent))
+    service = parser.parse(
+        stdlib_yaml, base_path, PurePath("STDLIB"), set(),
+    )[0]
+    service.merge(parser.parse(
+        input_yaml, base_path, template_name, set(),
+    )[0])
     service.visit("resolve_path", base_path)
     service.visit("resolve_reference", service)
 

--- a/src/opera/parser/tosca/v_1_3/service_template.py
+++ b/src/opera/parser/tosca/v_1_3/service_template.py
@@ -56,24 +56,36 @@ class ServiceTemplate(Entity):
         }, yaml_node.loc)
 
     @classmethod
-    def parse(cls, yaml_node, base_path, csar_path):
+    def parse(cls, yaml_node, base_path, template_path, parsed_templates):
         service = super().parse(yaml_node)
-        service.visit("prefix_path", csar_path)
-        service.merge_imports(base_path)
-        return service
+        service.visit("prefix_path", template_path.parent)
+        parsed = service.merge_imports(
+            base_path, parsed_templates | set([template_path]),
+        )
+        return service, parsed
 
-    def merge_imports(self, base_path):
+    def merge_imports(self, base_path, parsed_templates):
+        parsed = parsed_templates.copy()
+
         for import_def in self.data.get("imports", []):
             import_def.file.resolve_path(base_path)
             import_path = import_def.file.data
+
+            if import_path in parsed:
+                continue
+
             with (base_path / import_path).open() as fd:
                 yaml_data = yaml.load(fd, str(import_path))
-            self.merge(ServiceTemplate.parse(
-                yaml_data, base_path, import_path.parent,
-            ))
+            ast, parsed = ServiceTemplate.parse(
+                yaml_data, base_path, import_path, parsed,
+            )
+            self.merge(ast)
+
         # We do not need imports anymore, since they are preprocessor
         # construct and would only clutter the AST.
         self.data.pop("imports", None)
+
+        return parsed
 
     def merge(self, other):
         if self.tosca_definitions_version != other.tosca_definitions_version:

--- a/tests/opera/parser/test_tosca.py
+++ b/tests/opera/parser/test_tosca.py
@@ -101,3 +101,42 @@ class TestLoad:
 
         doc = tosca.load(tmp_path, name)
         assert doc.data_types["my_type"]
+
+    def test_duplicate_import(self, tmp_path, yaml_text):
+        name = pathlib.PurePath("template.yaml")
+        (tmp_path / name).write_text(yaml_text(
+            """
+            tosca_definitions_version: tosca_simple_yaml_1_3
+            imports: [ template.yaml ]
+            """
+        ))
+        tosca.load(tmp_path, name)
+
+    def test_imports_from_multiple_levels(self, tmp_path, yaml_text):
+        name = pathlib.PurePath("template.yaml")
+        (tmp_path / name).write_text(yaml_text(
+            """
+            tosca_definitions_version: tosca_simple_yaml_1_3
+            imports:
+              - subfolder/a.yaml
+              - subfolder/b.yaml
+            """
+        ))
+        (tmp_path / "subfolder").mkdir()
+        (tmp_path / "subfolder/a.yaml").write_text(yaml_text(
+            """
+            tosca_definitions_version: tosca_simple_yaml_1_3
+            imports:
+              - b.yaml
+            """
+        ))
+        (tmp_path / "subfolder/b.yaml").write_text(yaml_text(
+            """
+            tosca_definitions_version: tosca_simple_yaml_1_3
+            data_types:
+              my_type:
+                derived_from: tosca.datatypes.xml
+            """
+        ))
+
+        tosca.load(tmp_path, name)

--- a/tests/opera/parser/tosca/test_reference.py
+++ b/tests/opera/parser/tosca/test_reference.py
@@ -10,7 +10,7 @@ from opera.parser.yaml.node import Node
 
 
 class TestReferenceWrapperResolveReference:
-    def test_valid_type_reference(self, yaml_ast):
+    def test_valid_type_reference(self, yaml_ast, tmp_path):
         service = ServiceTemplate.parse(yaml_ast(
             """
             tosca_definitions_version: tosca_simple_yaml_1_3
@@ -18,13 +18,13 @@ class TestReferenceWrapperResolveReference:
               my.Type:
                 derived_from: tosca.nodes.Root
             """
-        ), None, None)
+        ), tmp_path, tmp_path, set())[0]
         ref = ReferenceWrapper("my.Type", None)
         ref.section_path = ("node_types",)
 
         assert service.node_types["my.Type"] == ref.resolve_reference(service)
 
-    def test_valid_template_reference(self, yaml_ast):
+    def test_valid_template_reference(self, yaml_ast, tmp_path):
         service = ServiceTemplate.parse(yaml_ast(
             """
             tosca_definitions_version: tosca_simple_yaml_1_3
@@ -33,14 +33,14 @@ class TestReferenceWrapperResolveReference:
                 my_node:
                   type: tosca.nodes.Root
             """
-        ), None, None)
+        ), tmp_path, tmp_path, set())[0]
         ref = ReferenceWrapper("my_node", None)
         ref.section_path = ("topology_template", "node_templates")
 
         target = service.topology_template.node_templates["my_node"]
         assert target == ref.resolve_reference(service)
 
-    def test_invalid_reference(self, yaml_ast):
+    def test_invalid_reference(self, yaml_ast, tmp_path):
         service = ServiceTemplate.parse(yaml_ast(
             """
             tosca_definitions_version: tosca_simple_yaml_1_3
@@ -48,7 +48,7 @@ class TestReferenceWrapperResolveReference:
               my.Type:
                 derived_from: tosca.nodes.Root
             """
-        ), None, None)
+        ), tmp_path, tmp_path, set())[0]
         ref = ReferenceWrapper("INVALID", None)
         ref.section_path = ("node_types",)
 
@@ -71,7 +71,7 @@ class TestDataTypeReferenceWrapperResolveReference:
         assert isinstance(result, Type)
         assert typ == result.data
 
-    def test_valid_user_data_type_reference(self, yaml_ast):
+    def test_valid_user_data_type_reference(self, yaml_ast, tmp_path):
         service = ServiceTemplate.parse(yaml_ast(
             """
             tosca_definitions_version: tosca_simple_yaml_1_3
@@ -79,7 +79,7 @@ class TestDataTypeReferenceWrapperResolveReference:
               my.Type:
                 derived_from: float
             """
-        ), None, None)
+        ), tmp_path, tmp_path, set())[0]
         ref = DataTypeReferenceWrapper("my.Type", None)
         ref.section_path = ("data_types",)
 

--- a/tests/opera/parser/tosca/v_1_3/test_service_template.py
+++ b/tests/opera/parser/tosca/v_1_3/test_service_template.py
@@ -21,7 +21,7 @@ class TestNormalizeDefinition:
 
 
 class TestParse:
-    def test_full(self, yaml_ast):
+    def test_full(self, yaml_ast, tmp_path):
         ServiceTemplate.parse(yaml_ast(
             """
             tosca_definitions_version: tosca_simple_yaml_1_3
@@ -48,18 +48,18 @@ class TestParse:
             policy_types: {}
             topology_template: {}
             """
-        ), None, None)
+        ), tmp_path, tmp_path, set())
 
-    def test_minimal(self, yaml_ast):
+    def test_minimal(self, yaml_ast, tmp_path):
         ServiceTemplate.parse(yaml_ast(
             """
             tosca_definitions_version: tosca_simple_yaml_1_3
             """
-        ), None, None)
+        ), tmp_path, tmp_path, set())
 
 
 class TestMerge:
-    def test_valid_section_merge(self, yaml_ast):
+    def test_valid_section_merge(self, yaml_ast, tmp_path):
         template = ServiceTemplate.parse(yaml_ast(
             """
             tosca_definitions_version: tosca_simple_yaml_1_3
@@ -67,7 +67,7 @@ class TestMerge:
               type_a:
                 derived_from: a
             """
-        ), None, None)
+        ), tmp_path, tmp_path, set())[0]
         template.merge(ServiceTemplate.parse(yaml_ast(
             """
             tosca_definitions_version: tosca_simple_yaml_1_3
@@ -75,13 +75,13 @@ class TestMerge:
               type_b:
                 derived_from: b
             """
-        ), None, None))
+        ), tmp_path, tmp_path, set())[0])
 
         assert len(template.node_types.data) == 2
         assert template.node_types["type_a"].data["derived_from"].data == "a"
         assert template.node_types["type_b"].data["derived_from"].data == "b"
 
-    def test_valid_merge(self, yaml_ast):
+    def test_valid_merge(self, yaml_ast, tmp_path):
         template = ServiceTemplate.parse(yaml_ast(
             """
             tosca_definitions_version: tosca_simple_yaml_1_3
@@ -89,7 +89,7 @@ class TestMerge:
               type_a:
                 derived_from: a
             """
-        ), None, None)
+        ), tmp_path, tmp_path, set())[0]
         template.merge(ServiceTemplate.parse(yaml_ast(
             """
             tosca_definitions_version: tosca_simple_yaml_1_3
@@ -97,12 +97,12 @@ class TestMerge:
               type_a:
                 derived_from: a
             """
-        ), None, None))
+        ), tmp_path, tmp_path, set())[0])
 
         assert len(template.data_types.data) == 1
         assert template.node_types["type_a"].data["derived_from"].data == "a"
 
-    def test_duplicates(self, yaml_ast):
+    def test_duplicates(self, yaml_ast, tmp_path):
         with pytest.raises(ParseError, match="type_a"):
             ServiceTemplate.parse(yaml_ast(
                 """
@@ -111,11 +111,11 @@ class TestMerge:
                   type_a:
                     derived_from: a
                 """
-            ), None, None).merge(ServiceTemplate.parse(yaml_ast(
+            ), tmp_path, tmp_path, set())[0].merge(ServiceTemplate.parse(yaml_ast(
                 """
                 tosca_definitions_version: tosca_simple_yaml_1_3
                 node_types:
                   type_a:
                     derived_from: b
                 """
-            ), None, None))
+            ), tmp_path, tmp_path, set())[0])


### PR DESCRIPTION
Currently opera throws duplicate key error when importing one template multiple times. This can be fixed by remembering which files have been already imported into the main TOSCA service template.