### PR TITLE
Add CI/CD Python 3.8 testing and PyPI deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,11 @@ executors:
       - image: circleci/python:3.7.4
     environment:
       PIPENV_VENV_IN_PROJECT: true
+  python38:
+    docker:
+      - image: circleci/python:3.8.2
+    environment:
+      PIPENV_VENV_IN_PROJECT: true
 
 jobs:
   test36:
@@ -30,6 +35,10 @@ jobs:
     executor: python37
     steps:
       - run_tests
+  test38:
+    executor: python38
+    steps:
+      - run_tests
 
 workflows:
   version: 2
@@ -37,3 +46,4 @@ workflows:
     jobs:
       - test36
       - test37
+      - test38

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,30 @@ commands:
   run_tests:
     description: Run test suite
     steps:
+      - common_setup
+      - run: make test
+
+  deploy_to_test_pypi:
+    description: Publish opera package to Python Package Index (PyPI) for testing
+    steps:
+      - common_setup
+      - run: env
+      - run: make build
+      - run: make test_release
+
+  deploy_to_production_pypi:
+    description: Publish opera package to Python Package Index (PyPI)
+    steps:
+      - common_setup
+      - run: make build
+      - run: make release
+
+  common_setup:
+    description: Prepare the repository for work
+    steps:
       - checkout
       - run: sudo pip install pipenv
       - run: make init
-      - run: make test
 
 executors:
   python36:
@@ -39,6 +59,14 @@ jobs:
     executor: python38
     steps:
       - run_tests
+  pypi_test_deploy:
+    executor: python37
+    steps:
+      - deploy_to_test_pypi
+  pypi_production_deploy:
+    executor: python37
+    steps:
+      - deploy_to_production_pypi
 
 workflows:
   version: 2
@@ -47,3 +75,22 @@ workflows:
       - test36
       - test37
       - test38
+      - pypi_test_deploy:
+          requires:
+            - test36
+            - test37
+            - test38
+          context: opera-test-pypi
+          filters:
+            branches:
+              only: master
+
+  deploy:
+    jobs:
+      - pypi_production_deploy:
+          context: opera-production-pypi
+          filters:
+            tags:
+              only: /[0-9]+\.[0-9]+\.[0-9]+/
+            branches:
+              ignore: /.*/

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,18 @@ test:
 
 fix:
 	pipenv run pytest -x tests
+
+build:
+	pipenv run python setup.py sdist bdist_wheel
+
+test_release: env-guard-TWINE_USERNAME env-guard-TWINE_PASSWORD
+	pipenv run twine upload --repository testpypi --non-interactive dist/*
+
+release: env-guard-TWINE_USERNAME env-guard-TWINE_PASSWORD
+	pipenv run twine upload --non-interactive dist/*
+
+env-guard-%:
+	@ if [ "${${*}}" = "" ]; then \
+	  echo "Environment variable $* not set"; \
+	  exit 1; \
+	fi

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,9 @@ verify_ssl = true
 [dev-packages]
 pytest = "*"
 selinux = "*"
+setuptools = "*"
+wheel = "*"
+twine = ">=3.0.0"
 
 [packages]
 opera = {editable = true,extras = ["openstack"],path = "."}


### PR DESCRIPTION
It's time to update our CI/CD pipeline by introducing changes 
that enable testing of the opera pip package with Python 3.8.
The new addon is also the ability to deploy opera Python package to
PyPI. This part is semi-automated and is invoked only by pushing a new
tag while on master branch.