### PR TITLE
Update setup.py and thereby fix publishing to test PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,4 +2,10 @@
 
 import setuptools
 
-setuptools.setup(use_scm_version=True)
+
+# configures that the local component of the version is constructed without commit hash
+def local_scheme(version):
+    return ""
+
+
+setuptools.setup(use_scm_version={"local_scheme": local_scheme})


### PR DESCRIPTION
To upload python package to PyPI its version field must be in the
format specified in PEP 440. This means that local component of the
version which comes after version number should be compatible with PEP
440. Publishing opera package to test PyPI instance was currently
failing due to invalid value for version which also included commit
hash(for example '0.5.7.dev2+g69f7164'). Therefore we had to update
setup.py to cut off the commit hash from the local component of the
version during the build process so that version can become valid(like
'0.5.7.dev2') and by that our package can be freely uploaded to PyPI.