### PR TITLE
Add first integration tests and daily/nightly xOpera CI/CD package testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,16 @@ commands:
       - run: make build
       - run: make release
 
+  create_and_push_stable_branch:
+    description: Create and push GitHub stable branch which points to the latest relased tag/commit
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "b6:94:61:c3:e1:8f:25:e5:43:6d:51:9e:43:c4:16:11"
+      - checkout
+      - run: git branch -f stable HEAD
+      - run: git push origin stable
+
 executors:
   python36:
     docker:
@@ -68,6 +78,10 @@ jobs:
     executor: python37
     steps:
       - deploy_to_production_pypi
+  push_stable_relase_branch:
+    executor: python37
+    steps:
+      - create_and_push_stable_branch
 
 workflows:
   version: 2
@@ -95,3 +109,6 @@ workflows:
               only: /[0-9]+\.[0-9]+\.[0-9]+/
             branches:
               ignore: /.*/
+      - push_stable_relase_branch:
+          requires:
+            - pypi_production_deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,19 @@
 version: "2.1"
 
 commands:
+  common_setup:
+    description: Prepare the repository for work
+    steps:
+      - checkout
+      - run: sudo pip install pipenv
+      - run: make init
+
   run_tests:
     description: Run test suite
     steps:
       - common_setup
       - run: make unit_test
+      - run: make integration_test
 
   deploy_to_test_pypi:
     description: Publish opera package to Python Package Index (PyPI) for testing
@@ -21,13 +29,6 @@ commands:
       - common_setup
       - run: make build
       - run: make release
-
-  common_setup:
-    description: Prepare the repository for work
-    steps:
-      - checkout
-      - run: sudo pip install pipenv
-      - run: make init
 
 executors:
   python36:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,15 @@ commands:
       - run: make unit_test
       - run: make integration_test
 
+  run_integration_tests_using_released_opera_version:
+    description: Test xOpera CLI commands with testing service template
+    steps:
+      - checkout
+      - run: pip install --user --upgrade pip
+      - run: pip install --user wheel
+      - run: pip install --user opera
+      - run: OPERA=opera make integration_test
+
   deploy_to_test_pypi:
     description: Publish opera package to Python Package Index (PyPI) for testing
     steps:
@@ -70,6 +79,10 @@ jobs:
     executor: python38
     steps:
       - run_tests
+  nightly_xopera_test:
+    executor: python37
+    steps:
+      - run_integration_tests_using_released_opera_version
   pypi_test_deploy:
     executor: python37
     steps:
@@ -112,3 +125,13 @@ workflows:
       - push_stable_relase_branch:
           requires:
             - pypi_production_deploy
+
+  nightly_test:
+    triggers:
+      - schedule:
+          cron: "0 3 * * *"
+          filters:
+            branches:
+              only: stable
+    jobs:
+      - nightly_xopera_test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+# List of all integration test scenarios
+integration_test_scenarios := $(wildcard tests/integration/*/runme.sh)
+
+# Default opera executable (tailored for developers). Can be overridden by
+# setting the OPERA environment variable to something else.
+OPERA ?= "pipenv run opera"
+
+# Point pipenv to the right file since we can execute tests from a subdir.
+export PIPENV_PIPFILE := $(realpath Pipfile)
+
 .PHONY: init
 init:
 	pipenv install -d
@@ -9,6 +19,13 @@ unit_test:
 .PHONY: fix
 fix:
 	pipenv run pytest -x tests
+
+.PHONY: integration_test
+integration_test: $(integration_test_scenarios)
+
+.PHONY: $(integration_test_scenarios)
+$(integration_test_scenarios):
+	cd $(dir $@) && bash $(notdir $@) $(OPERA)
 
 .PHONY: build
 build:

--- a/tests/integration/misc-tosca-types/inputs.yaml
+++ b/tests/integration/misc-tosca-types/inputs.yaml
@@ -1,0 +1,6 @@
+---
+# This yaml file contains inputs for service-template.yaml.
+
+host_ip: localhost
+slovenian_greeting: "Hej prijatelj, pojdi z nami!"
+...

--- a/tests/integration/misc-tosca-types/modules/artifact_types/test/test.yaml
+++ b/tests/integration/misc-tosca-types/modules/artifact_types/test/test.yaml
@@ -1,0 +1,9 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+artifact_types:
+  daily_test.artifacts.test:
+    derived_from: tosca.artifacts.File
+    mime_type: application/test
+    file_ext: [ test ]
+...

--- a/tests/integration/misc-tosca-types/modules/capability_types/test/test.yaml
+++ b/tests/integration/misc-tosca-types/modules/capability_types/test/test.yaml
@@ -1,0 +1,12 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+capability_types:
+  daily_test.capabilities.test:
+    derived_from: tosca.capabilities.Root
+    properties:
+      capability_property:
+        type: string
+        required: false
+        status: supported
+...

--- a/tests/integration/misc-tosca-types/modules/data_types/test/test.yaml
+++ b/tests/integration/misc-tosca-types/modules/data_types/test/test.yaml
@@ -1,0 +1,27 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+data_types:
+  daily_test.datatypes.test:
+    derived_from: tosca.datatypes.Root
+    properties:
+      a:
+        type: string
+        required: false
+      b:
+        type: integer
+        required: false
+        default: 3
+      c:
+        type: float
+        required: false
+        default: 0.5
+      d:
+        type: list
+        required: false
+        default: [1, 2, 3]
+      e:
+        type: map
+        required: false
+        default: { one: one, two: two }
+...

--- a/tests/integration/misc-tosca-types/modules/group_types/test/test.yaml
+++ b/tests/integration/misc-tosca-types/modules/group_types/test/test.yaml
@@ -1,0 +1,9 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+group_types:
+  daily_test.groups.test:
+    derived_from: tosca.groups.Root
+    description: My test group type for placing nodes of type Compute
+    members: [ tosca.nodes.Compute ]
+...

--- a/tests/integration/misc-tosca-types/modules/interface_types/test/test.yaml
+++ b/tests/integration/misc-tosca-types/modules/interface_types/test/test.yaml
@@ -1,0 +1,10 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+interface_types:
+  daily_test.interfaces.test:
+    derived_from: tosca.interfaces.Root
+    operations:
+      test_operation:
+        description: Simple operation for testing.
+...

--- a/tests/integration/misc-tosca-types/modules/node_types/file/file.yaml
+++ b/tests/integration/misc-tosca-types/modules/node_types/file/file.yaml
@@ -1,0 +1,16 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  daily_test.nodes.file:
+    derived_from: tosca.nodes.SoftwareComponent
+    interfaces:
+      Standard:
+        inputs:
+          file_content:
+            default: { get_input: file_content }
+            type: string
+        operations:
+          create: playbooks/create.yaml
+          delete: playbooks/delete.yaml
+...

--- a/tests/integration/misc-tosca-types/modules/node_types/file/playbooks/create.yaml
+++ b/tests/integration/misc-tosca-types/modules/node_types/file/playbooks/create.yaml
@@ -1,0 +1,16 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Create the new folder structure
+      file:
+        path: /tmp/opera-test/hello
+        recurse: true
+        state: directory
+
+    - name: Create hello.txt and add content
+      copy:
+        dest: /tmp/opera-test/hello/hello.txt
+        content: "{{ file_content }}"
+...

--- a/tests/integration/misc-tosca-types/modules/node_types/file/playbooks/delete.yaml
+++ b/tests/integration/misc-tosca-types/modules/node_types/file/playbooks/delete.yaml
@@ -1,0 +1,10 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Remove the location
+      file:
+        path: /tmp/opera-test
+        state: absent
+...

--- a/tests/integration/misc-tosca-types/modules/node_types/hello/hello.yaml
+++ b/tests/integration/misc-tosca-types/modules/node_types/hello/hello.yaml
@@ -1,0 +1,35 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  daily_test.nodes.hello:
+    derived_from: tosca.nodes.SoftwareComponent
+    properties:
+      slovenian_greeting:
+        type: string
+        description: Slovenian Greeting
+        default: Zdravo!
+      croatian_greeting:
+        type: string
+        description: Croatian Greeting
+        default: Cao đaci!
+    attributes:
+      something_to_pass_on:
+        type: string
+        description: Test for passing data between nodes
+        default: tralala
+    interfaces:
+      Standard:
+        inputs:
+          slovenian_greeting: {default: { get_property: [SELF, slovenian_greeting] }, type: string}
+          croatian_greeting: {default: { get_property: [SELF, croatian_greeting] }, type: string}
+          something_to_pass_on: {default: { get_attribute: [SELF, something_to_pass_on] }, type: string}
+        operations:
+          create:
+            implementation:
+              primary: playbooks/create.yaml
+              dependencies:
+                - playbooks/files/test.txt
+
+...
+

--- a/tests/integration/misc-tosca-types/modules/node_types/hello/playbooks/create.yaml
+++ b/tests/integration/misc-tosca-types/modules/node_types/hello/playbooks/create.yaml
@@ -1,0 +1,21 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say hello in Slovenian
+      debug:
+        msg: "{{ slovenian_greeting }}"
+
+    - name: Say hello like the do it in Croatia
+      debug:
+        msg: "{{ croatian_greeting }}"
+
+    - name: See what's in that linked file
+      shell: "cat test.txt"
+
+    - name: Set attributes for the setter node
+      set_stats:
+        data:
+          something_to_pass_on: "{{ something_to_pass_on }}"
+...

--- a/tests/integration/misc-tosca-types/modules/node_types/hello/playbooks/files/test.txt
+++ b/tests/integration/misc-tosca-types/modules/node_types/hello/playbooks/files/test.txt
@@ -1,0 +1,1 @@
+lalalalalalla

--- a/tests/integration/misc-tosca-types/modules/node_types/noimpl/noimpl.yaml
+++ b/tests/integration/misc-tosca-types/modules/node_types/noimpl/noimpl.yaml
@@ -1,0 +1,12 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  daily_test.nodes.noimpl:
+    derived_from: tosca.nodes.Root
+    properties:
+      test_integer:
+        type: integer
+      test_string:
+        type: string
+...

--- a/tests/integration/misc-tosca-types/modules/node_types/setter/playbooks/create.yaml
+++ b/tests/integration/misc-tosca-types/modules/node_types/setter/playbooks/create.yaml
@@ -1,0 +1,10 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Set attribute
+      set_stats:
+        data:
+          my_attribute: my_custom_attribute_value
+...

--- a/tests/integration/misc-tosca-types/modules/node_types/setter/setter.yaml
+++ b/tests/integration/misc-tosca-types/modules/node_types/setter/setter.yaml
@@ -1,0 +1,27 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  daily_test.nodes.setter:
+    derived_from: tosca.nodes.Root
+    attributes:
+      my_attribute:
+        type: string
+        default: my_default_attribute_default
+    properties:
+      my_property:
+        type: integer
+    interfaces:
+      Standard:
+        inputs:
+          receive_something: { default:  { get_attribute: [SELF, receives_notification, something_to_pass_on] }, type: string }
+        operations:
+          create: playbooks/create.yaml
+    requirements:
+      - host:
+          capability: tosca.capabilities.Compute
+          relationship: tosca.relationships.HostedOn
+      - receives_notification:
+          capability: tosca.capabilities.Compute
+          relationship: tosca.relationships.DependsOn
+...

--- a/tests/integration/misc-tosca-types/modules/node_types/test/playbooks/create.yaml
+++ b/tests/integration/misc-tosca-types/modules/node_types/test/playbooks/create.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say test
+      debug:
+        msg: "test"
+...

--- a/tests/integration/misc-tosca-types/modules/node_types/test/test.yaml
+++ b/tests/integration/misc-tosca-types/modules/node_types/test/test.yaml
@@ -1,0 +1,41 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+imports:
+  - ../../artifact_types/test/test.yaml
+  - ../../capability_types/test/test.yaml
+  - ../../data_types/test/test.yaml
+  - ../../interface_types/test/test.yaml
+  - ../../policy_types/test/test.yaml
+  - ../../relationship_types/test/test.yaml
+
+node_types:
+  daily_test.nodes.test:
+    derived_from: tosca.nodes.Root
+    metadata:
+      targetNamespace: "daily_test.nodes.test"
+      abstract: "false"
+      final: "false"
+    properties:
+      test:
+        type: daily_test.datatypes.test
+    interfaces:
+      Standard:
+        operations:
+          create:
+            implementation:
+              primary: playbooks/create.yaml
+      test:
+        type: daily_test.interfaces.test
+    artifacts:
+      test:
+        type: daily_test.artifacts.test
+        file: file.test
+    capabilities:
+      test:
+        type: daily_test.capabilities.test
+    requirements:
+      - host:
+          capability: tosca.capabilities.Compute
+          relationship: daily_test.relationships.test
+...

--- a/tests/integration/misc-tosca-types/modules/policy_types/test/test.yaml
+++ b/tests/integration/misc-tosca-types/modules/policy_types/test/test.yaml
@@ -1,0 +1,15 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+policy_types:
+  daily_test_policies.test:
+    derived_from: tosca.policies.Root
+    metadata:
+      targetNamespace: "daily_test_policies.test"
+      abstract: "false"
+      final: "false"
+    properties:
+      test_id:
+        type: string
+        description: Test identifier
+        required: false
+        status: supported

--- a/tests/integration/misc-tosca-types/modules/relationship_types/test/playbooks/test.yaml
+++ b/tests/integration/misc-tosca-types/modules/relationship_types/test/playbooks/test.yaml
@@ -1,0 +1,13 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say test
+      debug:
+        msg: "test"
+
+    - name: Print whatever lies in relationship_property
+      debug:
+        msg: "{{ relationship_property }}"
+...

--- a/tests/integration/misc-tosca-types/modules/relationship_types/test/test.yaml
+++ b/tests/integration/misc-tosca-types/modules/relationship_types/test/test.yaml
@@ -1,0 +1,20 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+relationship_types:
+  daily_test.relationships.test:
+    derived_from: tosca.relationships.HostedOn
+    properties:
+      relationship_property:
+        type: string
+        required: true
+    interfaces:
+      Configure:
+        operations:
+          configure_target:
+            inputs:
+              relationship_property:
+                default: { get_property: relationship_property }
+            implementation:
+              primary: playbooks/test.yaml
+...

--- a/tests/integration/misc-tosca-types/runme.sh
+++ b/tests/integration/misc-tosca-types/runme.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# get opera executable
+opera_executable="$1"
+
+# perform integration test
+$opera_executable validate -i inputs.yaml service-template.yaml
+$opera_executable deploy -i inputs.yaml service-template.yaml
+$opera_executable outputs
+$opera_executable undeploy

--- a/tests/integration/misc-tosca-types/service-template.yaml
+++ b/tests/integration/misc-tosca-types/service-template.yaml
@@ -1,0 +1,109 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+imports:
+  - modules/artifact_types/test/test.yaml
+  - modules/capability_types/test/test.yaml
+  - modules/data_types/test/test.yaml
+  - modules/interface_types/test/test.yaml
+  - modules/node_types/file/file.yaml
+  - modules/node_types/hello/hello.yaml
+  - modules/node_types/noimpl/noimpl.yaml
+  - modules/node_types/setter/setter.yaml
+  - modules/node_types/test/test.yaml
+  - modules/policy_types/test/test.yaml
+  - modules/relationship_types/test/test.yaml
+
+metadata:
+  targetNamespace: "daily_test.templates"
+  file_name: "service-template.yaml"
+
+description: This is a service template for daily testing with xOpera.
+namespace: "daily_test.templates"
+
+repositories:
+  test_repo:
+    description: Opera repository on GitHub
+    url: https://github.com/xlab-si/xopera-opera
+
+dsl_definitions:
+    test: &test test123
+
+topology_template:
+  inputs:
+    host_ip:
+      type: string
+    file_content:
+      type: string
+      description: Content for created file
+      default: "Hello from Ansible and xOpera!\n"
+    slovenian_greeting:
+      type: string
+      description: Greeting from Slovenia
+
+  node_templates:
+    my-workstation1:
+      type: tosca.nodes.Compute
+      attributes:
+        private_address: { get_input: host_ip }
+        public_address: { get_input: host_ip }
+
+    my-workstation2:
+      type: tosca.nodes.Compute
+      attributes:
+        private_address: { get_input: host_ip }
+        public_address: { get_input: host_ip }
+
+    file:
+      type: daily_test.nodes.file
+
+    hello:
+      type: daily_test.nodes.hello
+      properties:
+        slovenian_greeting: { get_input: slovenian_greeting }
+      requirements:
+        - host: my-workstation1
+
+    noimpl:
+      type: daily_test.nodes.noimpl
+      requirements:
+        - host: my-workstation1
+
+    setter:
+      type: daily_test.nodes.setter
+      properties:
+        my_property: 123
+      requirements:
+        - host: my-workstation1
+        - receives_notification: hello
+
+    test:
+      type: daily_test.nodes.test
+      requirements:
+        - host: my-workstation1
+
+  relationship_templates:
+    test:
+      type: daily_test.relationships.test
+      properties:
+        relationship_property: test123
+
+  groups:
+    workstation_group:
+      type: tosca.groups.Root
+      members: [ my-workstation1, my-workstation2 ]
+
+  policies:
+    test:
+      type: daily_test_policies.test
+      properties:
+        test_id: *test
+
+  outputs:
+    output_prop:
+      description: Example of property output
+      value: { get_property: [ setter, my_property ] }
+    output_attr:
+      description: Example of attribute output
+      value: { get_attribute: [ setter, my_attribute ] }
+...


### PR DESCRIPTION
With these additions we populate our CI/CD configuration with daily
testing of xOpera python package. This new testing routine will now
occur every night at 3 o'clock and will help us to be sure that the
latest version of the orchestrator is working properly.

CircleCI will trigger a job where the most important opera commands
will be tested. In the very beginning of this worklflow the last
version of opera pip package is installed. This is followed by opera
validate operation and the deployment which is performed on testing
CSAR that includes most common TOSCA definitions. And last but not
least, after the deployment we also look for outputs and later on use
the undeploy command to demolish the deployed solution.