### PR TITLE
Support for attribute mapping in operations

### DIFF
--- a/examples/attribute_mapping/playbooks/create-student.yaml
+++ b/examples/attribute_mapping/playbooks/create-student.yaml
@@ -1,0 +1,10 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+
+    - name: Set attributes
+      set_stats:
+        data:
+          student_id: "student-{{ id }}"

--- a/examples/attribute_mapping/playbooks/teacher-teaches-student--preconfigure-source.yaml
+++ b/examples/attribute_mapping/playbooks/teacher-teaches-student--preconfigure-source.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Append this relationship's source id
+      set_stats:
+        data:
+          new_list: "{{ student_ids + [ student_id ] }}"

--- a/examples/attribute_mapping/service.yaml
+++ b/examples/attribute_mapping/service.yaml
@@ -1,0 +1,101 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  steampunk.test.Student:
+    derived_from: tosca.nodes.Root
+    properties:
+      student_name:
+        type: string
+        description: The name of the student
+      enrolment_number:
+        type: integer
+        description: The number in the class register assigned to the student
+    attributes:
+      student_id:
+        type: string
+        description: Unique ID of the student.
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        operations:
+          create:
+            inputs:
+              id: { default: { get_property: [ SELF, enrolment_number ] } }
+            outputs:
+              student_id: [ SELF, student_id ]
+            implementation: playbooks/create-student.yaml
+
+  steampunk.test.Teacher:
+    derived_from: tosca.nodes.Root
+    requirements:
+      - student:
+          capability: tosca.capabilities.Root
+          relationship: steampunk.test.relationships.TeacherTeachesStudent
+    attributes:
+      student_ids:
+        type: list
+        description: >
+          The list of IDs of the students that the teacher teaches
+        default: []
+
+
+relationship_types:
+  steampunk.test.relationships.TeacherTeachesStudent:
+    derived_from: tosca.relationships.DependsOn
+    description: >
+      Associates a teacher with a student.
+    interfaces:
+      Configure:
+        operations:
+          pre_configure_source:
+            inputs:
+              student_id:
+                default: { get_attribute: [ TARGET, student_id ] }
+              student_ids:
+                default: { get_attribute: [ SOURCE, student_ids ] }
+            outputs:
+              new_list: [ SOURCE, student_ids ]
+            implementation: playbooks/teacher-teaches-student--preconfigure-source.yaml
+
+
+topology_template:
+
+  node_templates:
+
+    student-ben:
+      type: steampunk.test.Student
+      properties:
+        student_name: Ben
+        enrolment_number: 1
+
+    student-anne:
+      type: steampunk.test.Student
+      properties:
+        student_name: Anne
+        enrolment_number: 3
+
+    student-tina:
+      type: steampunk.test.Student
+      properties:
+        student_name: Tina
+        enrolment_number: 4
+
+    student-chris:
+      type: steampunk.test.Student
+      properties:
+        student_name: Tina
+        enrolment_number: 6
+
+    teacher-paul:
+      type: steampunk.test.Teacher
+      requirements:
+        - student: student-ben
+        - student: student-tina
+        - student: student-chris
+        - student: student-anne
+
+  outputs:
+    student_id_list:
+      type: list
+      description: The final list of IDs of Paul's students
+      value: { get_attribute: [ teacher-paul, student_ids ] }

--- a/src/opera/executor/ansible.py
+++ b/src/opera/executor/ansible.py
@@ -62,5 +62,5 @@ def run(host, primary, dependencies, vars):
             return False, {}
 
         with open(out) as fd:
-            attributes = json.load(fd)["global_custom_stats"]
-        return code == 0, attributes
+            outputs = json.load(fd)["global_custom_stats"]
+        return code == 0, outputs

--- a/src/opera/instance/base.py
+++ b/src/opera/instance/base.py
@@ -62,18 +62,20 @@ class Base:
         self.write()
 
     def run_operation(self, host, interface, operation):
-        success, attributes = self.template.run_operation(
+        success, outputs, attributes = self.template.run_operation(
             host, interface, operation, self,
         )
 
         if not success:
             raise OperationError("Failed")
 
+        for params, value in outputs:
+            self.map_attribute(params, value)
         self.update_attributes(attributes)
         self.write()
 
-    def update_attributes(self, attributes):
-        for name, value in attributes.items():
+    def update_attributes(self, outputs):
+        for name, value in outputs.items():
             self.set_attribute(name, value)
 
     def set_attribute(self, name, value):

--- a/src/opera/instance/node.py
+++ b/src/opera/instance/node.py
@@ -62,8 +62,8 @@ class Node(Base):
         self.set_state("created")
 
         self.set_state("configuring")
-        for requirement in self.template.requirements:
-            for relationship in self.out_edges[requirement.name].values():
+        for requirement in set([r.name for r in self.template.requirements]):
+            for relationship in self.out_edges[requirement].values():
                 relationship.run_operation(
                     "SOURCE", "Configure", "pre_configure_source",
                 )
@@ -73,8 +73,8 @@ class Node(Base):
                     "TARGET", "Configure", "pre_configure_target",
                 )
         self.run_operation("HOST", "Standard", "configure")
-        for requirement in self.template.requirements:
-            for relationship in self.out_edges[requirement.name].values():
+        for requirement in set([r.name for r in self.template.requirements]):
+            for relationship in self.out_edges[requirement].values():
                 relationship.run_operation(
                     "SOURCE", "Configure", "post_configure_source",
                 )

--- a/src/opera/instance/node.py
+++ b/src/opera/instance/node.py
@@ -144,3 +144,20 @@ class Node(Base):
 
     def get_input(self, params):
         return self.template.get_input(params)
+
+    def map_attribute(self, params, value):
+        host, attr, *rest = params
+
+        if host != "SELF":
+            raise DataError(
+                "Accessing non-local stuff is bad. Fix your service template."
+            )
+        if host == "HOST":
+            raise DataError("HOST is not yet supported in opera.")
+
+        # TODO(@tadeboro): Add support for nested attribute values once we
+        # have data type support.
+        if attr not in self.attributes:
+            raise DataError("Cannot find attribute '{}'.".format(attr))
+
+        self.set_attribute(attr, value)

--- a/src/opera/instance/relationship.py
+++ b/src/opera/instance/relationship.py
@@ -48,3 +48,18 @@ class Relationship(Base):
 
     def get_input(self, params):
         return self.template.get_input(params)
+
+    def map_attribute(self, params, value):
+        host, attr, *rest = params
+
+        if host not in ("SELF", "SOURCE", "TARGET"):
+            raise DataError(
+                "Accessing non-local stuff is bad. Fix your service template."
+            )
+
+        if host == "SOURCE":
+            self.source.map_attribute(["SELF", attr] + rest, value)
+        elif host == "TARGET":
+            self.target.map_attribute(["SELF", attr] + rest, value)
+        else:
+            self.set_attribute(attr, value)

--- a/src/opera/parser/tosca/v_1_3/collector_mixin.py
+++ b/src/opera/parser/tosca/v_1_3/collector_mixin.py
@@ -103,6 +103,18 @@ class CollectorMixin:
                         ", ".join(undeclared_inputs),
                     ), self.loc)
 
+                # Outputs, which define the attribute mapping, come from:
+                #  1. inteface operation definition,
+                #  2. inteface operation assignment in template section
+                outputs = {
+                    k: [s.data for s in v.data]
+                    for k, v in op_definition.get("outputs", {}).items()
+                }
+                outputs.update({
+                    k: [s.data for s in v.data]
+                    for k, v in op_assignment.get("outputs", {}).items()
+                })
+
                 # Operation implementation details
                 impl = (
                     op_assignment.get("implementation") or
@@ -122,6 +134,7 @@ class CollectorMixin:
                         d.file.data for d in impl.get("dependencies", [])
                     ],
                     inputs=inputs,
+                    outputs=outputs,
                     timeout=timeout,
                     host=operation_host,
                 )

--- a/src/opera/parser/tosca/v_1_3/operation_definition_for_template.py
+++ b/src/opera/parser/tosca/v_1_3/operation_definition_for_template.py
@@ -16,7 +16,7 @@ class OperationDefinitionForTemplate(Entity):
         description=String,
         implementation=OperationImplementationDefinition,
         inputs=Map(Void),
-        outputs=Map(List(Void)),
+        outputs=Map(List(String)),
     )
 
     @classmethod

--- a/src/opera/parser/tosca/v_1_3/operation_definition_for_type.py
+++ b/src/opera/parser/tosca/v_1_3/operation_definition_for_type.py
@@ -17,7 +17,7 @@ class OperationDefinitionForType(Entity):
         description=String,
         implementation=OperationImplementationDefinition,
         inputs=Map(ParameterDefinition),
-        outputs=Map(List(Void)),
+        outputs=Map(List(String)),
     )
 
     @classmethod

--- a/src/opera/template/node.py
+++ b/src/opera/template/node.py
@@ -70,7 +70,7 @@ class Node:
         operation = self.interfaces[interface].operations.get(operation)
         if operation:
             return operation.run(host, instance)
-        return True, {}
+        return True, {}, {}
 
     #
     # TOSCA functions
@@ -119,3 +119,19 @@ class Node:
 
     def get_input(self, params):
         return self.topology.get_input(params)
+
+    def map_attribute(self, params, value):
+        host, prop, *rest = params
+
+        if host != "SELF":
+            raise DataError(
+                "Accessing non-local stuff is bad. Fix your service template."
+            )
+        if host == "HOST":
+            raise DataError("HOST is not yet supported in opera.")
+
+        if len(self.instances) != 1:
+            raise DataError(
+                "Mapping an attribute for multiple instances not supported")
+
+        next(iter(self.instances.values())).map_attribute(params, value)

--- a/src/opera/template/operation.py
+++ b/src/opera/template/operation.py
@@ -1,12 +1,15 @@
+from opera.error import DataError
 from opera.executor import ansible
 
 
 class Operation:
-    def __init__(self, name, primary, dependencies, inputs, timeout, host):
+    def __init__(self, name, primary, dependencies, inputs, outputs, timeout,
+                 host):
         self.name = name
         self.primary = primary
         self.dependencies = dependencies
         self.inputs = inputs
+        self.outputs = outputs
         self.timeout = timeout
         self.host = host
 
@@ -32,7 +35,26 @@ class Operation:
         }
 
         # TODO(@tadeboro): Generalize executors.
-        return ansible.run(
+        success, ansible_outputs = ansible.run(
             actual_host, str(self.primary),
             tuple(str(i) for i in self.dependencies), operation_inputs,
         )
+        if not success:
+            return False, {}, {}
+
+        outputs = []
+        unresolved_outputs = []
+
+        for output, attribute_mapping in self.outputs.items():
+            if output in ansible_outputs:
+                outputs.append((attribute_mapping, ansible_outputs[output]))
+                ansible_outputs.pop(output)
+            else:
+                unresolved_outputs.append(output)
+
+        if len(unresolved_outputs) > 0:
+            raise DataError(
+                "Operation did not return the following outputs: {}".format(
+                    ", ".join(unresolved_outputs)))
+
+        return success, outputs, ansible_outputs

--- a/src/opera/template/relationship.py
+++ b/src/opera/template/relationship.py
@@ -20,7 +20,7 @@ class Relationship:
         operation = self.interfaces[interface].operations.get(operation)
         if operation:
             return operation.run(host, instance)
-        return True, {}
+        return True, {}, {}
 
     #
     # TOSCA functions

--- a/tests/unit/opera/instance/test_attribute_mapping.py
+++ b/tests/unit/opera/instance/test_attribute_mapping.py
@@ -1,0 +1,128 @@
+import pathlib
+
+import pytest
+
+from opera.error import DataError
+from opera.parser import tosca
+from opera.storage import Storage
+
+
+class TestAttributeMapping:
+    @pytest.fixture
+    def service_template(self, tmp_path, yaml_text):
+        name = pathlib.PurePath("template.yaml")
+        (tmp_path / name).write_text(yaml_text(
+            """
+            tosca_definitions_version: tosca_simple_yaml_1_3
+            node_types:
+              my_base_type:
+                derived_from: tosca.nodes.Root
+                attributes:
+                  colour:
+                    type: string
+              my_node_type:
+                derived_from: my_base_type
+              my_collector_node_type:
+                derived_from: my_base_type
+                requirements:
+                  - my_target:
+                      capability: tosca.capabilities.Root
+                      relationship: my_relationship_type
+            relationship_types:
+              my_relationship_type:
+                derived_from: tosca.relationships.Root
+                attributes:
+                  colour:
+                    type: string
+
+            topology_template:
+              node_templates:
+                my_node:
+                  type: my_node_type
+                my_collector:
+                  type: my_collector_node_type
+                  requirements:
+                    - my_target: my_node
+            """
+        ))
+        storage = Storage(tmp_path / pathlib.Path(".opera"))
+        storage.write("template.yaml", "root_file")
+        ast = tosca.load(tmp_path, name)
+        template = ast.get_template({})
+        topology = template.instantiate(storage)
+        yield template
+
+    def test_map_attribute_node(self, service_template):
+        node = service_template.find_node("my_node")
+        node.map_attribute(["SELF", "colour"], "green")
+        assert "green" == node.get_attribute(["SELF", "colour"])
+
+    @pytest.mark.parametrize("host",
+                             ["SOURCE", "TARGET", "HOST" "my_collector",
+                              "other"])
+    def test_map_attribute_node_bad_host(self, service_template, host):
+        node = service_template.find_node("my_node")
+        with pytest.raises(DataError, match="Accessing non-local stuff"):
+          node.map_attribute([host, "colour"], "black")
+
+    def test_map_attribute_node_bad_attribute(self, service_template):
+        node = service_template.find_node("my_node")
+        with pytest.raises(DataError, match="Cannot find attribute"):
+          node.map_attribute(["SELF", "volume"], "loud")
+
+    def test_map_attribute_relationship_source(self, service_template):
+      node_source = service_template.find_node("my_collector")
+      node_source_instance = next(iter(node_source.instances.values()))
+      relationship_instance = next(
+        iter(node_source_instance.out_edges["my_target"].values()))
+
+      relationship_instance.map_attribute(["SOURCE", "colour"], "ochre")
+
+      assert "ochre" == node_source.get_attribute(["SELF", "colour"])
+
+    def test_map_attribute_relationship_target(self, service_template):
+      node_target = service_template.find_node("my_node")
+      node_source = service_template.find_node("my_collector")
+      node_source_instance = next(iter(node_source.instances.values()))
+      relationship_instance = next(
+        iter(node_source_instance.out_edges["my_target"].values()))
+
+      relationship_instance.map_attribute(["TARGET", "colour"], "magenta")
+
+      assert "magenta" == node_target.get_attribute(["SELF", "colour"])
+
+    def test_map_attribute_relationship_self(self, service_template):
+      node_source = service_template.find_node("my_collector")
+      node_source_instance = next(iter(node_source.instances.values()))
+      relationship_instance = next(
+        iter(node_source_instance.out_edges["my_target"].values()))
+
+      relationship_instance.map_attribute(["SELF", "colour"], "steampunk")
+
+      assert "steampunk" == relationship_instance.get_attribute(
+          ["SELF", "colour"])
+
+    @pytest.mark.parametrize("host",
+                             ["HOST", "my_node", "my_collector", "other"])
+    def test_map_attribute_relationship_bad_host(self, service_template, host):
+      node_source = service_template.find_node("my_collector")
+      node_source_instance = next(iter(node_source.instances.values()))
+      relationship_instance = next(
+        iter(node_source_instance.out_edges["my_target"].values()))
+
+      with pytest.raises(DataError, match="Accessing non-local stuff"):
+        relationship_instance.map_attribute([host, "colour"], "ochre")
+
+    @pytest.mark.parametrize("host, pattern", [
+                                ("SELF", "Instance has no 'volume' attribute"),
+                                ("SOURCE", "Cannot find attribute 'volume'."),
+                                ("TARGET", "Cannot find attribute 'volume'.")
+                            ])
+    def test_map_attr_rel_bad_attr(self, service_template, host, pattern):
+      node_source = service_template.find_node("my_collector")
+      node_source_instance = next(iter(node_source.instances.values()))
+      relationship_instance = next(
+        iter(node_source_instance.out_edges["my_target"].values()))
+
+      with pytest.raises(DataError, match=pattern):
+        relationship_instance.map_attribute([host, "volume"], "quiet")

--- a/tests/unit/opera/parser/tosca/v_1_3/test_operation_definition_for_type.py
+++ b/tests/unit/opera/parser/tosca/v_1_3/test_operation_definition_for_type.py
@@ -35,7 +35,7 @@ class TestParse:
               input:
                 type: string
             outputs:
-              output: [1, 2, 3, 4, 5]
+              my_output: [ SELF, attribute_name ]
             """
         ))
 


### PR DESCRIPTION
*TOSCA Simple Profile in YAML Version 1.3* specifies in Section 3.6.17, that an operation may include keyname `outputs`, which is a map of attribute mappings. This then interpreted as *an optional map of attribute mappings that specify named operation output values and their mappings onto attributes of the node_type or relationship that contains the interface within which the operation is defined.*
There is an example of usage in Section 2.16.1.

This PR implements the support for this feature. We are now able in each operation to specify a list of key names that the operation's implementation returns at the end of its running. For each key, we can provide a mapping to an attribute that will receive the new value. We support referencing attributes of the current node template's instance in node template interfaces (`SELF`), and referencing the target (`TARGET`) or the source (`SOURCE`) of a relationship as well as the relationship's instance (`SELF`) as well.

The enclosed example illustrates the use of resource mapping in an example, where we have one node of type A that depends on multiple nodes of type B. For its operation, each instance of type A needs to keep a list of the dependencies' of all instances of the dependent type B instance.