### PR TITLE
Implement the ability to relocate .opera storage folder

### DIFF
--- a/src/opera/commands/deploy.py
+++ b/src/opera/commands/deploy.py
@@ -6,12 +6,17 @@ import yaml
 from opera.error import DataError, ParseError
 from opera.parser import tosca
 from opera.storage import Storage
+from os import path
 
 
 def add_parser(subparsers):
     parser = subparsers.add_parser(
         "deploy",
         help="Deploy service template from CSAR"
+    )
+    parser.add_argument(
+        "--instance-path", "-p",
+        help=".opera storage folder location"
     )
     parser.add_argument(
         "--inputs", "-i", type=argparse.FileType("r"),
@@ -24,7 +29,10 @@ def add_parser(subparsers):
 
 
 def deploy(args):
-    storage = Storage(Path(".opera"))
+    if args.instance_path and not path.isdir(args.instance_path):
+        raise argparse.ArgumentTypeError("Directory {0} is not a valid path!".format(args.instance_path))
+
+    storage = Storage(Path(args.instance_path).joinpath(".opera")) if args.instance_path else Storage(Path(".opera"))
     storage.write(args.csar.name, "root_file")
 
     # TODO(@tadeboro): This should be part of the init command that we do not

--- a/src/opera/commands/outputs.py
+++ b/src/opera/commands/outputs.py
@@ -7,12 +7,17 @@ import yaml
 from opera.error import DataError, ParseError
 from opera.parser import tosca
 from opera.storage import Storage
+from os import path
 
 
 def add_parser(subparsers):
     parser = subparsers.add_parser(
         "outputs",
         help="Retrieve service template outputs"
+    )
+    parser.add_argument(
+        "--instance-path", "-p",
+        help=".opera storage folder location"
     )
     parser.add_argument(
         "--format", "-f", choices=("yaml", "json"), type=str,
@@ -22,7 +27,10 @@ def add_parser(subparsers):
 
 
 def outputs(args):
-    storage = Storage(Path(".opera"))
+    if args.instance_path and not path.isdir(args.instance_path):
+        raise argparse.ArgumentTypeError("Directory {0} is not a valid path!".format(args.instance_path))
+
+    storage = Storage(Path(args.instance_path).joinpath(".opera")) if args.instance_path else Storage(Path(".opera"))
     root = storage.read("root_file")
     inputs = storage.read_json("inputs")
 

--- a/src/opera/commands/undeploy.py
+++ b/src/opera/commands/undeploy.py
@@ -4,6 +4,7 @@ from pathlib import Path, PurePath
 from opera.error import DataError, ParseError
 from opera.parser import tosca
 from opera.storage import Storage
+from os import path
 
 
 def add_parser(subparsers):
@@ -11,11 +12,18 @@ def add_parser(subparsers):
         "undeploy",
         help="Undeploy service template"
     )
+    parser.add_argument(
+        "--instance-path", "-p",
+        help=".opera storage folder location"
+    )
     parser.set_defaults(func=undeploy)
 
 
 def undeploy(args):
-    storage = Storage(Path(".opera"))
+    if args.instance_path and not path.isdir(args.instance_path):
+        raise argparse.ArgumentTypeError("Directory {0} is not a valid path!".format(args.instance_path))
+
+    storage = Storage(Path(args.instance_path).joinpath(".opera")) if args.instance_path else Storage(Path(".opera"))
     root = storage.read("root_file")
     inputs = storage.read_json("inputs")
 


### PR DESCRIPTION
Within this update we are improving some of opera's commands by adding
the -l (or --location) command line option that brings the possibility
to control the location where opera will store the information about
orchestration and deployment. So with these changes user can now
specify the location of the .opera folder along with opera deploy,
undeploy and outputs commands.

Hitherto xOpera created the aforementioned .opera storage folder in the
current working directory which resulted in the lack of flexibility
when deploying the (same) solutions multiple times. Now there is a
chance to use use the same deployment CSARs with several executions of
opera without any interference. Users will be able to relocate and store
orchestration info to the suitable locations which will also make
those things reusable and easier for testing the deployment.

I've tested the changes locally and have run the following commands on integration test CSAR example:

```console
# deploy
opera deploy -l src/ -i tests/integration/misc-tosca-types/inputs.yaml tests/integration/misc-tosca-types/service-template.yaml
# udeploy
opera outputs --location src/
# outputs
opera undeploy --location /src
```

There might still be some room for improvement (if this gets approved) like:

- adding unit tests for the new option
- considering the possibility to add `--location` option as a global parameter

cc @sstanovnik this could be useful for your SaaS API/xOpera API

