### PR TITLE
Support targets keyname in policy type definitions

### DIFF
--- a/src/opera/parser/tosca/reference.py
+++ b/src/opera/parser/tosca/reference.py
@@ -30,6 +30,41 @@ class DataTypeReferenceWrapper(ReferenceWrapper):
         return super().resolve_reference(service_template)
 
 
+class MultipleReferenceWrapper(String):
+    def __init__(self, data, loc):
+        super().__init__(data, loc)
+        self.section_paths = ()
+
+    def resolve_reference(self, service_template):
+        assert self.section_paths, "Missing section path"
+
+        # Special case for root types that should have no parent
+        if self.data == "tosca.entity.Root":
+            return None
+
+        path_exists = False
+        target_result = None
+        targets = []
+        for section_path in self.section_paths:
+            target = service_template.dig(*section_path, self.data)
+            if target:
+                path_exists = True
+                targets.append(target)
+                target_result = target
+
+        if len(targets) > 1:
+            self.abort(
+                "Duplicate policy targets names were found: {}. Try to use unique names.".format(
+                    str(['/'.join(path_tuple) + "/" + str(self.data) for path_tuple in self.section_paths])
+                ), self.loc)
+
+        if not path_exists:
+            self.abort("Invalid reference, {} is not in {}".format(
+                str(self.data), str(['/'.join(path_tuple) for path_tuple in self.section_paths])
+            ), self.loc)
+        return target_result
+
+
 class Reference:
     WRAPPER_CLASS = ReferenceWrapper
 
@@ -44,6 +79,19 @@ class Reference:
     def parse(self, yaml_node):
         ref = self.WRAPPER_CLASS.parse(yaml_node)
         ref.section_path = self.section_path
+        return ref
+
+
+class ReferenceXOR:
+    WRAPPER_CLASS = MultipleReferenceWrapper
+
+    def __init__(self, *references):
+        assert references, "References should not be empty"
+        self.references = references
+
+    def parse(self, yaml_node):
+        ref = self.WRAPPER_CLASS.parse(yaml_node)
+        ref.section_paths = self.references
         return ref
 
 

--- a/src/opera/parser/tosca/v_1_3/policy_definition.py
+++ b/src/opera/parser/tosca/v_1_3/policy_definition.py
@@ -1,6 +1,7 @@
 from ..entity import Entity
+from ..list import List
 from ..map import Map
-from ..reference import Reference
+from ..reference import Reference, ReferenceXOR
 from ..string import String
 from ..void import Void
 
@@ -11,6 +12,10 @@ class PolicyDefinition(Entity):
         description=String,
         metadata=Map(String),
         properties=Map(Void),
-        # TODO(@tadeboro): targets, triggers
+        targets=List(ReferenceXOR(("topology_template", "node_templates"), ("topology_template", "groups")))
+        # TODO(@tadeboro): triggers
     )
     REQUIRED = {"type"}
+
+    def get_targets(self):
+        return

--- a/src/opera/parser/tosca/v_1_3/policy_type.py
+++ b/src/opera/parser/tosca/v_1_3/policy_type.py
@@ -1,7 +1,7 @@
 from ..entity import TypeEntity
+from ..list import List
 from ..map import Map
-from ..reference import Reference
-from ..string import String
+from ..reference import Reference, ReferenceXOR
 
 from .property_definition import PropertyDefinition
 
@@ -10,5 +10,6 @@ class PolicyType(TypeEntity):
     REFERENCE = Reference("policy_types")
     ATTRS = dict(
         properties=Map(PropertyDefinition),
-        # TODOD(@tadeboro): Add targets, triggers
+        targets=List(ReferenceXOR("node_types", "group_types"))
+        # TODO(@tadeboro): Add triggers
     )

--- a/tests/integration/misc-tosca-types/service-template.yaml
+++ b/tests/integration/misc-tosca-types/service-template.yaml
@@ -5,6 +5,7 @@ imports:
   - modules/artifact_types/test/test.yaml
   - modules/capability_types/test/test.yaml
   - modules/data_types/test/test.yaml
+  - modules/group_types/test/test.yaml
   - modules/interface_types/test/test.yaml
   - modules/node_types/file/file.yaml
   - modules/node_types/hello/hello.yaml
@@ -90,7 +91,7 @@ topology_template:
 
   groups:
     workstation_group:
-      type: tosca.groups.Root
+      type: daily_test.groups.test
       members: [ my-workstation1, my-workstation2 ]
 
   policies:
@@ -98,6 +99,7 @@ topology_template:
       type: daily_test_policies.test
       properties:
         test_id: *test
+      targets: [ hello, setter, workstation_group ]
 
   outputs:
     output_prop:

--- a/tests/unit/opera/parser/tosca/v_1_3/test_policy_definition.py
+++ b/tests/unit/opera/parser/tosca/v_1_3/test_policy_definition.py
@@ -10,6 +10,7 @@ class TestParse:
             metadata: {}
             properties:
               prop: 6.7
+            targets: [node_type_a, node_type_b, node_type_c]
             """
         ))
 

--- a/tests/unit/opera/parser/tosca/v_1_3/test_policy_type.py
+++ b/tests/unit/opera/parser/tosca/v_1_3/test_policy_type.py
@@ -11,6 +11,7 @@ class TestParse:
               key: value
             version: "1.2"
             properties: {}
+            targets: [ node_type, group_type ]
             """
         ))
 


### PR DESCRIPTION
In this commit we are updating our TOSCA parser with the support for
policy type targets which is an optional list of valid node types or
group types the policy type can be applied to. When used is
node_templates section of the main TOSCA service templates policy
targets represent the optional list of names of node templates or
groups that the actual policy gets applied to. Contents of this
commit are also linked to the issue #32. The only thing that still
needs to be implemented are policy type triggers.