### PR TITLE
Incorporate the support for compressed CSAR files

### DIFF
--- a/src/opera/commands/__init__.py
+++ b/src/opera/commands/__init__.py
@@ -2,5 +2,6 @@ from opera.commands import (
     outputs,
     deploy,
     undeploy,
-    validate
+    validate,
+    init
 )

--- a/src/opera/commands/deploy.py
+++ b/src/opera/commands/deploy.py
@@ -39,7 +39,7 @@ def deploy(args):
     if args.instance_path and not path.isdir(args.instance_path):
         raise argparse.ArgumentTypeError("Directory {0} is not a valid path!".format(args.instance_path))
 
-    storage = Storage(Path(args.instance_path) / ".opera") if args.instance_path else Storage(Path(".opera"))
+    storage = Storage(Path(args.instance_path)) if args.instance_path else Storage(Path(".opera"))
 
     if args.workers < 1:
         print("{0} is not a positive number!".format(args.workers))

--- a/src/opera/commands/init.py
+++ b/src/opera/commands/init.py
@@ -1,0 +1,107 @@
+import argparse
+from os import path
+from pathlib import Path, PurePath
+from zipfile import ZipFile, is_zipfile
+
+import yaml
+
+from opera.error import DataError, ParseError
+from opera.parser import tosca
+from opera.storage import Storage
+from opera.parser.tosca.csar import CloudServiceArchive
+
+
+def add_parser(subparsers):
+    parser = subparsers.add_parser(
+        "init",
+        help="Initialize the deployment environment for the service template or CSAR"
+    )
+    parser.add_argument(
+        "--instance-path", "-p",
+        help=".opera storage folder location"
+    )
+    parser.add_argument(
+        "--inputs", "-i", type=argparse.FileType("r"),
+        help="YAML file with inputs",
+    )
+    parser.add_argument("csar",
+                        type=argparse.FileType("r"),
+                        help="Cloud service archive or service template file")
+    parser.set_defaults(func=init)
+
+
+def init(args):
+    if args.instance_path and not path.isdir(args.instance_path):
+        raise argparse.ArgumentTypeError("Directory {0} is not a valid path!".format(args.instance_path))
+
+    storage = Storage(Path(args.instance_path) / ".opera") if args.instance_path else Storage(Path(".opera"))
+
+    if is_zipfile(args.csar.name):
+        initialize_compressed_csar(args, storage)
+    else:
+        storage.write(args.csar.name, "root_file")
+        initialize_service_template(args, storage)
+
+
+def initialize_service_template(args, storage):
+    try:
+        inputs = yaml.safe_load(args.inputs) if args.inputs else {}
+        storage.write_json(inputs, "inputs")
+    except Exception as e:
+        print("Invalid inputs: {}".format(e))
+        return 1
+
+    try:
+        ast = tosca.load(Path.cwd(), PurePath(args.csar.name))
+        template = ast.get_template(inputs)
+        template.instantiate(storage)
+    except ParseError as e:
+        print("{}: {}".format(e.loc, e))
+        return 1
+    except DataError as e:
+        print(str(e))
+        return 1
+
+    print("Service template was initialized")
+    return 0
+
+
+def initialize_compressed_csar(args, storage):
+    csars_dir = Path(storage.path) / "csars"
+    csars_dir.mkdir(exist_ok=True)
+    csar_name = args.csar.name
+
+    try:
+        inputs = yaml.safe_load(args.inputs) if args.inputs else {}
+        storage.write_json(inputs, "inputs")
+    except Exception as e:
+        print("Invalid inputs: {}".format(e))
+        return 1
+
+    try:
+        # validate csar
+        csar = CloudServiceArchive(csar_name, csars_dir)
+        tosca_service_template = csar.validate_csar()
+
+        # unzip csar and save the path to storage
+        csar_dir = csars_dir / Path("csar")
+        ZipFile(csar_name, 'r').extractall(csar_dir)
+        csar_tosca_service_template_path = csar_dir / tosca_service_template
+        storage.write(str(csar_tosca_service_template_path), "root_file")
+
+        # try to initiate service template from csar
+        ast = tosca.load(Path.cwd(), csar_tosca_service_template_path)
+        template = ast.get_template(inputs)
+        template.instantiate(storage)
+    except ParseError as e:
+        print("{}: {}".format(e.loc, e))
+        return 1
+    except DataError as e:
+        print(str(e))
+        return 1
+    except Exception as e:
+        print("Invalid CSAR: {}".format(e))
+        return 1
+
+    print("CSAR was initialized")
+    return 0

--- a/src/opera/commands/init.py
+++ b/src/opera/commands/init.py
@@ -34,7 +34,7 @@ def init(args):
     if args.instance_path and not path.isdir(args.instance_path):
         raise argparse.ArgumentTypeError("Directory {0} is not a valid path!".format(args.instance_path))
 
-    storage = Storage(Path(args.instance_path) / ".opera") if args.instance_path else Storage(Path(".opera"))
+    storage = Storage(Path(args.instance_path)) if args.instance_path else Storage(Path(".opera"))
 
     if is_zipfile(args.csar.name):
         initialize_compressed_csar(args, storage)

--- a/src/opera/commands/outputs.py
+++ b/src/opera/commands/outputs.py
@@ -30,7 +30,7 @@ def outputs(args):
     if args.instance_path and not path.isdir(args.instance_path):
         raise argparse.ArgumentTypeError("Directory {0} is not a valid path!".format(args.instance_path))
 
-    storage = Storage(Path(args.instance_path).joinpath(".opera")) if args.instance_path else Storage(Path(".opera"))
+    storage = Storage(Path(args.instance_path) / ".opera") if args.instance_path else Storage(Path(".opera"))
     root = storage.read("root_file")
     inputs = storage.read_json("inputs")
 

--- a/src/opera/commands/outputs.py
+++ b/src/opera/commands/outputs.py
@@ -30,7 +30,7 @@ def outputs(args):
     if args.instance_path and not path.isdir(args.instance_path):
         raise argparse.ArgumentTypeError("Directory {0} is not a valid path!".format(args.instance_path))
 
-    storage = Storage(Path(args.instance_path) / ".opera") if args.instance_path else Storage(Path(".opera"))
+    storage = Storage(Path(args.instance_path)) if args.instance_path else Storage(Path(".opera"))
     root = storage.read("root_file")
     inputs = storage.read_json("inputs")
 

--- a/src/opera/commands/undeploy.py
+++ b/src/opera/commands/undeploy.py
@@ -29,7 +29,7 @@ def undeploy(args):
     if args.instance_path and not path.isdir(args.instance_path):
         raise argparse.ArgumentTypeError("Directory {0} is not a valid path!".format(args.instance_path))
 
-    storage = Storage(Path(args.instance_path).joinpath(".opera")) if args.instance_path else Storage(Path(".opera"))
+    storage = Storage(Path(args.instance_path) / ".opera") if args.instance_path else Storage(Path(".opera"))
     root = storage.read("root_file")
     inputs = storage.read_json("inputs")
 

--- a/src/opera/commands/undeploy.py
+++ b/src/opera/commands/undeploy.py
@@ -29,7 +29,7 @@ def undeploy(args):
     if args.instance_path and not path.isdir(args.instance_path):
         raise argparse.ArgumentTypeError("Directory {0} is not a valid path!".format(args.instance_path))
 
-    storage = Storage(Path(args.instance_path) / ".opera") if args.instance_path else Storage(Path(".opera"))
+    storage = Storage(Path(args.instance_path)) if args.instance_path else Storage(Path(".opera"))
     root = storage.read("root_file")
     inputs = storage.read_json("inputs")
 

--- a/src/opera/parser/tosca/csar.py
+++ b/src/opera/parser/tosca/csar.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from zipfile import ZipFile
+
+import yaml
+from opera.error import ParseError
+
+
+class CloudServiceArchive:
+    def __init__(self, csar_name, csar_folder_path):
+        self._csar_name = csar_name
+        self._csar_folder_path = csar_folder_path
+        self._tosca_meta = None
+        self._root_yaml_template = None
+        self._metadata = None
+
+    def validate_csar(self):
+        with TemporaryDirectory(dir=self._csar_folder_path) as tempdir:
+            ZipFile(self._csar_name, 'r').extractall(tempdir)
+
+            try:
+                meta_file_path = Path(tempdir) / "TOSCA-Metadata" / "TOSCA.meta"
+                if meta_file_path.exists():
+                    with meta_file_path.open() as meta_file:
+                        self._tosca_meta = yaml.safe_load(meta_file)
+
+                    self._validate_csar_version()
+                    self._validate_tosca_meta_file_version()
+                    template_entry = self._get_entry_definitions()
+                    self._get_created_by()
+                    self._get_other_definitions()
+
+                    # check if 'Entry-Definitions' points to an existing template file in the CSAR
+                    if not Path(tempdir).joinpath(template_entry).exists():
+                        raise ParseError('The file "{}" defined within "Entry-Definitions" in '
+                                         '"TOSCA-Metadata/TOSCA.meta" does not exist.'.format(template_entry), self)
+
+                    return template_entry
+                else:
+                    root_yaml_files = []
+
+                    root_yaml_files.extend(Path(tempdir).glob('*.yaml'))
+                    root_yaml_files.extend(Path(tempdir).glob('*.yml'))
+
+                    if len(root_yaml_files) != 1:
+                        raise ParseError("There should be one root level yaml "
+                                         "file in the root of the CSAR: {}.".format(root_yaml_files), self)
+
+                    with Path(root_yaml_files[0]).open() as root_template:
+                        root_yaml_template = yaml.safe_load(root_template)
+                        self._metadata = root_yaml_template.get('metadata')
+
+                    self._get_template_version()
+                    self._get_template_name()
+                    self._get_author()
+
+                    return root_yaml_files[0].name
+            except Exception as e:
+                raise ParseError("Invalid CSAR structure: {}".format(e), self)
+
+    def _validate_csar_version(self):
+        csar_version = self._tosca_meta.get('CSAR-Version')
+        if csar_version and csar_version != 1.1:
+            raise ParseError('CSAR-Version entry in the CSAR {} is '
+                             'required to denote version 1.1".'.format(self._csar_name), self)
+        return csar_version
+
+    def _validate_tosca_meta_file_version(self):
+        tosca_meta_file_version = self._tosca_meta.get('TOSCA-Meta-File-Version')
+        if tosca_meta_file_version and tosca_meta_file_version != 1.1:
+            raise ParseError('TOSCA-Meta-File-Version entry in the CSAR {} is '
+                             'required to denote version 1.1".'.format(self._csar_name), self)
+        return tosca_meta_file_version
+
+    def _get_entry_definitions(self):
+        if 'Entry-Definitions' not in self._tosca_meta:
+            raise ParseError('The CSAR "{}" is missing the required metadata "Entry-Definitions" in '
+                             '"TOSCA-Metadata/TOSCA.meta".'.format(self._csar_name), self)
+        return self._tosca_meta.get('Entry-Definitions')
+
+    def _get_created_by(self):
+        return self._tosca_meta.get('Created-By')
+
+    def _get_other_definitions(self):
+        return self._tosca_meta.get('Other-Definitions')
+
+    def _get_template_version(self):
+        if "template_version" not in self._metadata:
+            raise Exception('The CSAR "{}" is missing the required '
+                            'template_version in metadata".'.format(self._csar_name))
+        return self._metadata.get('template_version')
+
+    def _get_template_name(self):
+        if "template_version" not in self._metadata:
+            raise ParseError('The CSAR "{}" is missing the required'
+                             ' template_name in metadata".'.format(self._csar_name), self)
+        return self._metadata.get('template_name')
+
+    def _get_author(self):
+        return self._metadata.get('template_author')

--- a/src/opera/storage.py
+++ b/src/opera/storage.py
@@ -22,3 +22,7 @@ class Storage:
 
     def read_json(self, *path):
         return json.loads(self.read(*path))
+
+    def exists(self, *path):
+        return (self.path / pathlib.PurePath(*path)).exists()
+

--- a/tests/integration/misc-tosca-types/TOSCA-Metadata/TOSCA.meta
+++ b/tests/integration/misc-tosca-types/TOSCA-Metadata/TOSCA.meta
@@ -1,0 +1,4 @@
+TOSCA-Meta-File-Version: 1.1
+CSAR-Version: 1.1
+Created-By: OASIS TOSCA TC
+Entry-Definitions: service-template.yaml

--- a/tests/integration/misc-tosca-types/runme.sh
+++ b/tests/integration/misc-tosca-types/runme.sh
@@ -4,8 +4,16 @@ set -euo pipefail
 # get opera executable
 opera_executable="$1"
 
-# perform integration test
+# perform integration test with service template
 $opera_executable validate -i inputs.yaml service-template.yaml
 $opera_executable deploy -i inputs.yaml service-template.yaml
+$opera_executable outputs
+$opera_executable undeploy
+
+# integration test with compressed CSAR
+rm -rf .opera
+zip -r test.csar service-template.yaml modules TOSCA-Metadata
+$opera_executable init -i inputs.yaml test.csar
+$opera_executable deploy
 $opera_executable outputs
 $opera_executable undeploy


### PR DESCRIPTION
Up until now opera supported deploying uncompressed CSARs, but not the
compressed version of CSAR file. Here we accomplished that opera will
recognize also zip compressed TOSCA template files and will allow to
either deploy or undeploy the service template from CSAR. These
changes are linked to the issue #27 that provided the enhancement.

I have tested these changes locally with:

```console
# deploy compressed test.csar
opera deploy -i inputs.yaml -t service-template.yaml test.csar

# udeploy the compressed CSAR
opera undeploy -c test.csar
```

If needed I can also provide an integration test with compressed CSAR and those new CLI options.

cc @cankarm  just mentioning you because it was you who filed this issue and because this was one of the important requirements for the the RADON project. 
