### PR TITLE
Welcome the support for private ssh key files

### DIFF
--- a/src/opera/executor/ansible.py
+++ b/src/opera/executor/ansible.py
@@ -19,6 +19,9 @@ def _get_inventory(host):
         inventory["ansible_python_interpreter"] = sys.executable
     else:
         inventory["ansible_user"] = os.environ.get("OPERA_SSH_USER", "centos")
+        opera_ssh_identity_file = os.environ.get("OPERA_SSH_IDENTITY_FILE")
+        if opera_ssh_identity_file is not None:
+            inventory["ansible_ssh_private_key_file"] = opera_ssh_identity_file
 
     return yaml.safe_dump(dict(all=dict(hosts=dict(opera=inventory))))
 


### PR DESCRIPTION
This commit includes upgrades of our Ansible executor and we can
therefore announce a new supported environment variable called
OPERA_SSH_IDENTITY_FILE which addresses the needs explained in #57.

Till now xOpera orchestrator offered only OPERA_SSH_USER environment
variable which is used by the Ansible executor when establishing the
connection to a remote machine to tell which user someone wants to
connect as. But as time passed by we realized that it could be useful
for the user to be able to choose ssh keys to connect to remote VMs.

This feature relieves the user of managing this part all by himself
since it is know that the situations where users have too many ssh key
files on their machines occur frequently. In this cases just putting
the keys to the ~/.ssh folder is not enough and often this is resolved
by creating ~/.ssh/config configuration file which offers matching IPs
and ssh keys for the connection. The OPERA_SSH_IDENTITY_FILE env var
is used to point to the file with a private ssh key that needs to be
used when establishing a secure connection to the host. Behind all that
now we apply that file to the Ansible inventory created within the
opera's Ansible executor by using a special behavioural inventory
parameter named ansible_ssh_private_key_file.