### PR TITLE
Implement concurrent deploy/undeploy execution

### DIFF
--- a/src/opera/commands/undeploy.py
+++ b/src/opera/commands/undeploy.py
@@ -16,6 +16,12 @@ def add_parser(subparsers):
         "--instance-path", "-p",
         help=".opera storage folder location"
     )
+    parser.add_argument(
+        "--workers", "-w",
+        help="Maximum number of concurrent undeployment \
+            threads (positive number, default 1)",
+        type=int, default=1
+    )
     parser.set_defaults(func=undeploy)
 
 
@@ -27,11 +33,15 @@ def undeploy(args):
     root = storage.read("root_file")
     inputs = storage.read_json("inputs")
 
+    if args.workers < 1:
+        print("{0} is not a positive number!".format(args.workers))
+        return 1
+
     try:
         ast = tosca.load(Path.cwd(), PurePath(root))
         template = ast.get_template(inputs)
         topology = template.instantiate(storage)
-        topology.undeploy()
+        topology.undeploy(args.workers)
     except ParseError as e:
         print("{}: {}".format(e.loc, e))
         return 1

--- a/src/opera/executor/ansible.py
+++ b/src/opera/executor/ansible.py
@@ -6,6 +6,7 @@ import tempfile
 import yaml
 
 from . import utils
+from opera.threading import utils as thread_utils
 
 
 def _get_inventory(host):
@@ -51,14 +52,15 @@ def run(host, primary, dependencies, vars):
         )
         code, out, err = utils.run_in_directory(dir_path, cmd, env)
         if code != 0:
+            thread_utils.print_thread("------------")
             with open(out) as fd:
                 for l in fd:
                     print(l.rstrip())
-            print("------------")
+            thread_utils.print_thread("------------")
             with open(err) as fd:
                 for l in fd:
                     print(l.rstrip())
-            print("============")
+            thread_utils.print_thread("============")
             return False, {}
 
         with open(out) as fd:

--- a/src/opera/instance/node.py
+++ b/src/opera/instance/node.py
@@ -1,6 +1,6 @@
 from opera.error import DataError
-
 from .base import Base
+from opera.threading import utils as thread_utils
 
 
 class Node(Base):
@@ -15,7 +15,7 @@ class Node(Base):
 
         for requirement in self.template.requirements:
             rname = requirement.name
-            self.out_edges[rname] =  self.out_edges.get(rname, {})
+            self.out_edges[rname] = self.out_edges.get(rname, {})
 
             for target in requirement.target.instances.values():
                 target.in_edges[rname] = target.in_edges.get(rname, {})
@@ -55,7 +55,7 @@ class Node(Base):
         return self.template.get_host() or "localhost"
 
     def deploy(self):
-        print("  Deploying {}".format(self.tosca_id))
+        thread_utils.print_thread("  Deploying {}".format(self.tosca_id))
 
         self.set_state("creating")
         self.run_operation("HOST", "Standard", "create")
@@ -90,9 +90,12 @@ class Node(Base):
         self.set_state("started")
 
         # TODO(@tadeboro): Execute various add hooks
+        thread_utils.print_thread(
+            "  Deployment of {} complete".format(self.tosca_id)
+        )
 
     def undeploy(self):
-        print("  Undeploying {}".format(self.tosca_id))
+        thread_utils.print_thread("  Undeploying {}".format(self.tosca_id))
 
         self.set_state("stopping")
         self.run_operation("HOST", "Standard", "stop")
@@ -107,6 +110,9 @@ class Node(Base):
         self.reset_attributes()
         self.write()
 
+        thread_utils.print_thread(
+            "  Undeployment of {} complete".format(self.tosca_id)
+        )
     #
     # TOSCA functions
     #

--- a/src/opera/template/operation.py
+++ b/src/opera/template/operation.py
@@ -1,5 +1,6 @@
 from opera.error import DataError
 from opera.executor import ansible
+from opera.threading import utils as thread_utils
 
 
 class Operation:
@@ -14,7 +15,9 @@ class Operation:
         self.host = host
 
     def run(self, host, instance):
-        print("    Executing {} on {}".format(self.name, instance.tosca_id))
+        thread_utils.print_thread(
+            "    Executing {} on {}".format(self.name, instance.tosca_id)
+        )
 
         # TODO(@tadeboro): Respect the timeout option.
         # TODO(@tadeboro): Add host validation.

--- a/src/opera/threading/__init__.py
+++ b/src/opera/threading/__init__.py
@@ -1,0 +1,3 @@
+from opera.threading.node_executor import (
+    NodeExecutor
+)

--- a/src/opera/threading/node_executor.py
+++ b/src/opera/threading/node_executor.py
@@ -1,0 +1,59 @@
+from concurrent.futures import ThreadPoolExecutor, wait
+from opera.error import OperationError
+
+WORKER_PREFIX = 'Worker'
+
+
+class NodeExecutor(ThreadPoolExecutor):
+    def __init__(self, num_workers=None):
+        super().__init__(
+            max_workers=num_workers,
+            thread_name_prefix=WORKER_PREFIX
+        )
+        self.futures = {}
+        self.processed_nodes = set()
+
+    def not_submitted(self, node_id):
+        return node_id not in self.processed_nodes
+
+    def submit_operation(self, operation, node_id):
+        self.processed_nodes.add(node_id)
+        self.futures[self.submit(operation)] = node_id
+
+    def wait_results(self):
+        proceed = bool(self.futures)
+
+        results = wait(
+            self.futures,
+            return_when="FIRST_COMPLETED"
+        )
+        errors = self.process_results(results)
+
+        if errors:
+            # if errors occurred
+            # wait for all running operations to complete
+            # and halt execution
+            results = wait(
+                self.futures,
+                return_when="ALL_COMPLETED"
+            )
+            errors.update(self.process_results(results))
+            for node_id in errors:
+                print("Error processing node {0}: {1}".format(
+                    node_id, errors[node_id])
+                )
+            raise OperationError("Failed")
+
+        return proceed
+
+    def process_results(self, results):
+        errors = {}
+        for future in results.done:
+            node_id = self.futures.pop(future)
+            try:
+                future.result()
+                self.processed_nodes.remove(node_id)
+            except Exception as e:
+                errors[node_id] = e
+
+        return errors

--- a/src/opera/threading/utils.py
+++ b/src/opera/threading/utils.py
@@ -1,0 +1,5 @@
+from threading import current_thread
+
+
+def print_thread(str):
+    print("[{}] {}".format(current_thread().name, str))

--- a/tests/integration/concurrency/playbooks/sleep.yaml
+++ b/tests/integration/concurrency/playbooks/sleep.yaml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - command:
+        cmd: sleep "{{ time }}"

--- a/tests/integration/concurrency/runme.sh
+++ b/tests/integration/concurrency/runme.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+# get opera executable
+opera_executable="$1"
+
+# perform integration test
+$opera_executable deploy -w 10 service.yaml
+$opera_executable undeploy -w 10

--- a/tests/integration/concurrency/service.yaml
+++ b/tests/integration/concurrency/service.yaml
@@ -1,0 +1,140 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  hello_type:
+    derived_from: tosca.nodes.SoftwareComponent
+    properties:
+      time:
+        default: "1" 
+        type: string     
+    interfaces:
+      Standard:
+        inputs:
+          time:
+            default: { get_property: [SELF, time] } 
+            type: string            
+        operations:
+          create: playbooks/sleep.yaml
+          start: playbooks/sleep.yaml
+          delete: playbooks/sleep.yaml
+
+topology_template:
+  inputs:
+    marker:
+      type: string
+      default: default-marker
+
+  node_templates:
+    my-workstation:
+      type: tosca.nodes.Compute
+      attributes:
+        private_address: localhost
+        public_address: localhost
+
+    hello-1:
+      type: hello_type
+      properties:
+        time: "5"
+      requirements:
+        - host: my-workstation
+
+    hello-2:
+      type: hello_type
+      properties:
+        time: "5"
+      requirements:
+        - host: my-workstation     
+        
+    hello-3:
+      type: hello_type
+      properties:
+        time: "1"
+      requirements:
+        - host: my-workstation     
+        
+    hello-4:
+      type: hello_type
+      properties:
+        time: "1"
+      requirements:
+        - host: my-workstation         
+        
+    hello-5:
+      type: hello_type
+      properties:
+        time: "1"
+      requirements:
+        - host: my-workstation
+        - dependency:  hello-1
+
+    hello-6:
+      type: hello_type
+      properties:
+        time: "1"
+      requirements:
+        - host: my-workstation
+        - dependency:  hello-5            
+
+    hello-7:
+      type: hello_type
+      properties:
+        time: "3"
+      requirements:
+        - host: my-workstation     
+        - dependency:  hello-6
+
+    hello-8:
+      type: hello_type
+      properties:
+        time: "5"
+      requirements:
+        - host: my-workstation
+
+    hello-9:
+      type: hello_type
+      properties:
+        time: "1"
+      requirements:
+        - host: my-workstation     
+        
+    hello-10:
+      type: hello_type
+      properties:
+        time: "3"
+      requirements:
+        - host: my-workstation     
+        
+    hello-11:
+      type: hello_type
+      properties:
+        time: "1"
+      requirements:
+        - host: my-workstation
+        - dependency:  hello-1
+
+    hello-12:
+      type: hello_type
+      properties:
+        time: "2"
+      requirements:
+        - host: my-workstation
+        - dependency:  hello-3            
+
+    hello-13:
+      type: hello_type
+      properties:
+        time: "3"
+      requirements:
+        - host: my-workstation     
+        - dependency:  hello-4        
+
+    hello-14:
+      type: hello_type
+      properties:
+        time: "1"
+      requirements:
+        - host: my-workstation
+        - dependency:  hello-1
+        - dependency:  hello-2
+        - dependency:  hello-7
+        - dependency:  hello-13


### PR DESCRIPTION
In order to improve deployment/undeployment performance, execution is parallelized. In the situation when direct acyclic graph representing the node dependencies can be drawn as a tree with separate branches xOpera runs operations concurrently.

A new parameter "-w" is introduced in order to indicate the maximum number of concurrent threads. If omitted, xOpera executes all operations sequentially.