### PR TITLE
Supplement get_artifact TOSCA function

### DIFF
--- a/examples/artifacts/files/file.txt
+++ b/examples/artifacts/files/file.txt
@@ -1,0 +1,1 @@
+This is an example file content.

--- a/examples/artifacts/playbooks/create.yaml
+++ b/examples/artifacts/playbooks/create.yaml
@@ -1,0 +1,14 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: See what's in that linked file
+      command: "cat {{ file }}"
+      register: file_contents
+
+    - name: Set attribute
+      set_stats:
+        data:
+          my_attribute: "{{ file_contents.stdout }}"
+...

--- a/examples/artifacts/service.yaml
+++ b/examples/artifacts/service.yaml
@@ -1,0 +1,32 @@
+---
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  opera.nodes.file:
+    derived_from: tosca.nodes.SoftwareComponent
+    attributes:
+      my_attribute:
+        type: string
+    interfaces:
+      Standard:
+        operations:
+          create:
+            implementation: playbooks/create.yaml
+            inputs:
+              file:
+                default: { get_artifact: [ SELF, file ] }
+    artifacts:
+        file:
+          type: tosca.artifacts.File
+          file: files/file.txt
+
+topology_template:
+  node_templates:
+    artifacts_file:
+      type: opera.nodes.file
+
+  outputs:
+    output_attr:
+      description: Example of attribute output
+      value: { get_attribute: [ artifacts_file, my_attribute ] }
+...

--- a/src/opera/executor/ansible.py
+++ b/src/opera/executor/ansible.py
@@ -27,12 +27,14 @@ def _get_inventory(host):
     return yaml.safe_dump(dict(all=dict(hosts=dict(opera=inventory))))
 
 
-def run(host, primary, dependencies, vars, verbose):
+def run(host, primary, dependencies, artifacts, vars, verbose):
     with tempfile.TemporaryDirectory() as dir_path:
         playbook = os.path.join(dir_path, os.path.basename(primary))
         utils.copy(primary, playbook)
         for d in dependencies:
             utils.copy(d, os.path.join(dir_path, os.path.basename(d)))
+        for a in artifacts:
+            utils.copy(a, os.path.join(dir_path, os.path.basename(a)))
         inventory = utils.write(
             dir_path, _get_inventory(host), suffix=".yaml",
         )

--- a/src/opera/instance/node.py
+++ b/src/opera/instance/node.py
@@ -184,3 +184,6 @@ class Node(Base):
             raise DataError("Cannot find attribute '{}'.".format(attr))
 
         self.set_attribute(attr, value)
+
+    def get_artifact(self, params):
+        return self.template.get_artifact(params)

--- a/src/opera/instance/relationship.py
+++ b/src/opera/instance/relationship.py
@@ -63,3 +63,17 @@ class Relationship(Base):
             self.target.map_attribute(["SELF", attr] + rest, value)
         else:
             self.set_attribute(attr, value)
+
+    def get_artifact(self, params):
+        host, prop, *rest = params
+
+        if host not in ("SELF", "SOURCE", "TARGET"):
+            raise DataError(
+                "Accessing non-local stuff is bad. Fix your service template."
+            )
+
+        if host == "SOURCE":
+            return self.source.get_property(["SELF", prop] + rest)
+        if host == "TARGET":
+            return self.target.get_property(["SELF", prop] + rest)
+        return self.template.get_artifact(params)

--- a/src/opera/parser/tosca/v_1_3/artifact_definition.py
+++ b/src/opera/parser/tosca/v_1_3/artifact_definition.py
@@ -1,4 +1,7 @@
 from opera.parser.yaml.node import Node
+from opera.value import Value
+
+import yaml
 
 from ..entity import Entity
 from ..map import Map
@@ -7,7 +10,6 @@ from ..reference import Reference
 from ..string import String
 from ..version import Version
 from ..void import Void
-
 
 
 class ArtifactDefinition(Entity):
@@ -34,3 +36,14 @@ class ArtifactDefinition(Entity):
                 Node("file"): yaml_node,
             })
         return yaml_node
+
+    def get_value(self, typ):
+        if "file" in self:
+            yaml_data = yaml.safe_load(str(self.file))
+            return Value(typ, True, yaml_data)
+        return Value(typ, False)
+
+    def get_value_type(self, service_ast):
+        # TODO(@tadeboro): Implement types later.
+        return None
+

--- a/src/opera/parser/tosca/v_1_3/definition_collector_mixin.py
+++ b/src/opera/parser/tosca/v_1_3/definition_collector_mixin.py
@@ -43,3 +43,6 @@ class DefinitionCollectorMixin:
             defs[name]["operations"].update(definition.get("operations", {}))
 
         return dict(defs)
+
+    def collect_artifact_definitions(self, service_ast):
+        return self._collect_definitions("artifacts", service_ast)

--- a/src/opera/parser/tosca/v_1_3/node_template.py
+++ b/src/opera/parser/tosca/v_1_3/node_template.py
@@ -48,6 +48,7 @@ class NodeTemplate(CollectorMixin, Entity):
             requirements=self.collect_requirements(name, service_ast),
             capabilities=self.collect_capabilities(service_ast),
             interfaces=self.collect_interfaces(service_ast),
+            artifacts=self.collect_artifacts(service_ast),
         )
 
     # Next function is not part of the CollectorMixin, because requirements

--- a/src/opera/template/node.py
+++ b/src/opera/template/node.py
@@ -1,5 +1,9 @@
 from opera.error import DataError
 from opera.instance.node import Node as Instance
+from pathlib import Path
+
+import tempfile, os
+from ..executor import utils
 
 
 class Node:
@@ -12,6 +16,7 @@ class Node:
             requirements,
             capabilities,
             interfaces,
+            artifacts,
     ):
         self.name = name
         self.types = types
@@ -20,6 +25,7 @@ class Node:
         self.requirements = requirements
         self.capabilities = capabilities
         self.interfaces = interfaces
+        self.artifacts = artifacts
 
         # This will be set when the node is inserted into a topology
         self.topology = None
@@ -153,3 +159,32 @@ class Node:
                 "Mapping an attribute for multiple instances not supported")
 
         next(iter(self.instances.values())).map_attribute(params, value)
+
+    def get_artifact(self, params):
+        host, prop, *rest = params
+
+        location = None
+        remove = None
+
+        if len(rest) == 1:
+            location = rest[0]
+
+        if len(rest) == 2:
+            location, remove = rest
+
+        if host != "SELF":
+            raise DataError(
+                "Accessing non-local stuff is bad. Fix your service template."
+            )
+        if host == "HOST":
+            raise DataError("HOST is not yet supported in opera.")
+
+        if location == "LOCAL_FILE":
+            raise DataError("Location get_artifact property is not yet supported in opera.")
+
+        if remove:
+            raise DataError("Remove get_artifact property artifacts is not yet supported in opera.")
+
+        if prop in self.artifacts:
+            self.artifacts[prop].eval(self)
+            return Path(self.artifacts[prop].data).name

--- a/src/opera/template/operation.py
+++ b/src/opera/template/operation.py
@@ -4,11 +4,11 @@ from opera.threading import utils as thread_utils
 
 
 class Operation:
-    def __init__(self, name, primary, dependencies, inputs, outputs, timeout,
-                 host):
+    def __init__(self, name, primary, dependencies, artifacts, inputs, outputs, timeout, host):
         self.name = name
         self.primary = primary
         self.dependencies = dependencies
+        self.artifacts = artifacts
         self.inputs = inputs
         self.outputs = outputs
         self.timeout = timeout
@@ -40,7 +40,8 @@ class Operation:
         # TODO(@tadeboro): Generalize executors.
         success, ansible_outputs = ansible.run(
             actual_host, str(self.primary),
-            tuple(str(i) for i in self.dependencies), operation_inputs, verbose
+            tuple(str(i) for i in self.dependencies),
+            tuple(str(i) for i in self.artifacts), operation_inputs, verbose,
         )
         if not success:
             return False, {}, {}

--- a/src/opera/template/topology.py
+++ b/src/opera/template/topology.py
@@ -63,3 +63,8 @@ class Topology:
         node_name, *rest = params
 
         return self.find_node(node_name).get_attribute(["SELF"] + rest)
+
+    def get_artifact(self, params):
+        node_name, *rest = params
+
+        return self.find_node(node_name).get_artifact(["SELF"] + rest)

--- a/src/opera/value.py
+++ b/src/opera/value.py
@@ -8,6 +8,7 @@ class Value:
         "get_attribute",
         "get_input",
         "get_property",
+        "get_artifact",
     ))
 
     def __init__(self, typ, present, data=None):


### PR DESCRIPTION
Now the time is right to replenish our opera orchestrator with the
support for get_artifact TOSCA function which is generally used to
extract artifact location between modelable TOSCA entities that are
defined within the same service template. The desire for this useful
enhancement has also been the main topic of the issue #59.

The implemented TOSCA artifact function can be useful to link the
prepared orchestration artifacts (e.g. zipped FaaS function files)
directly to a TOSCA service template. Most likely the users will use
get_artifact function when setting the default value for interface
operation inputs and then later on retrieve them during the
orchestration in the Ansible playbook actuators on demand.

With these additions we supported all the parameters defined in TOSCA
specification that can be used in get_artifact (modelable_entity_name,
artifact_name, location and remove params). The defined artifacts need
to be at hand when referenced by TOSCA function and thus we copy them
to a temporary directory during the execution which is similar to
operation dependencies.
________________________________________________________________________________

This PR is still in its initial state and will probably need a lot of polishing before we can accept it. I did not implement all the `get_artifact` TOSCA function parameters like it's said in the commit description but I assumed that we will likely want to support them (or maybe not). The ones that have been left out are `location` and `remove` parameters that will need some extra attention because they interfere with the orchestration process itself. The definition of the `get_artifact` function from the [TOSCA YAML provile v1.3 spec](https://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.3/cos01/TOSCA-Simple-Profile-YAML-v1.3-cos01.html#_Toc26969460) is shown on the image below.

![image](https://user-images.githubusercontent.com/41727816/85384042-0505f680-b541-11ea-9968-41cd35aea30f.png)

This PR also provides an example of `get_artifact` TOSCA function usage that can be found in `examples/artifacts` folder. It came in handy for the testing of the implementation using the commands below:

```console
(.venv) anzoman@ubuntu:~/Desktop/xopera-opera$ opera deploy examples/artifacts/service.yaml 
  Deploying artifacts_file_0
    Executing create on artifacts_file_0
(.venv) anzoman@ubuntu:~/Desktop/xopera-opera$ opera outputs
output_attr:
  description: Example of attribute output
  value: This is an example file content.
```



