### PR TITLE
Include verbose mode for opera CLI commands

### DIFF
--- a/src/opera/commands/deploy.py
+++ b/src/opera/commands/deploy.py
@@ -29,6 +29,10 @@ def add_parser(subparsers):
             threads (positive number, default 1)",
         type=int, default=1
     )
+    parser.add_argument(
+        "--verbose", "-v", action='store_true',
+        help="Turns on verbose mode",
+    )
     parser.add_argument("template",
                         type=argparse.FileType("r"), nargs='?',
                         help="TOSCA YAML service template file",
@@ -67,7 +71,7 @@ def _parser_callback(args):
         return 1
 
     try:
-        deploy(service_template, inputs, storage, args.workers)
+        deploy(service_template, inputs, storage, args.verbose, args.workers)
     except ParseError as e:
         print("{}: {}".format(e.loc, e))
         return 1
@@ -78,7 +82,7 @@ def _parser_callback(args):
     return 0
 
 
-def deploy(service_template: str, inputs: typing.Optional[dict], storage: Storage, num_workers: int):
+def deploy(service_template: str, inputs: typing.Optional[dict], storage: Storage, verbose_mode: bool, num_workers: int):
     """
     :raises ParseError:
     :raises DataError:
@@ -94,4 +98,4 @@ def deploy(service_template: str, inputs: typing.Optional[dict], storage: Storag
     ast = tosca.load(Path.cwd(), PurePath(service_template))
     template = ast.get_template(inputs)
     topology = template.instantiate(storage)
-    topology.deploy(num_workers)
+    topology.deploy(verbose_mode, num_workers)

--- a/src/opera/commands/init.py
+++ b/src/opera/commands/init.py
@@ -25,6 +25,10 @@ def add_parser(subparsers):
         "--inputs", "-i", type=argparse.FileType("r"),
         help="YAML file with inputs",
     )
+    parser.add_argument(
+        "--verbose", "-v", action='store_true',
+        help="Turns on verbose mode",
+    )
     parser.add_argument("csar",
                         type=argparse.FileType("r"),
                         help="Cloud service archive or service template file")

--- a/src/opera/commands/outputs.py
+++ b/src/opera/commands/outputs.py
@@ -23,6 +23,10 @@ def add_parser(subparsers):
         "--format", "-f", choices=("yaml", "json"), type=str,
         default="yaml", help="Output format",
     )
+    parser.add_argument(
+        "--verbose", "-v", action='store_true',
+        help="Turns on verbose mode",
+    )
     parser.set_defaults(func=_parser_callback)
 
 

--- a/src/opera/commands/undeploy.py
+++ b/src/opera/commands/undeploy.py
@@ -22,6 +22,10 @@ def add_parser(subparsers):
             threads (positive number, default 1)",
         type=int, default=1
     )
+    parser.add_argument(
+        "--verbose", "-v", action='store_true',
+        help="Turns on verbose mode",
+    )
     parser.set_defaults(func=_parser_callback)
 
 
@@ -35,7 +39,7 @@ def _parser_callback(args):
 
     storage = Storage.create(args.instance_path)
     try:
-        undeploy(storage, args.workers)
+        undeploy(storage, args.verbose, args.workers)
     except ParseError as e:
         print("{}: {}".format(e.loc, e))
         return 1
@@ -46,7 +50,7 @@ def _parser_callback(args):
     return 0
 
 
-def undeploy(storage: Storage, num_workers: int):
+def undeploy(storage: Storage, verbose_mode: bool, num_workers: int):
     """
     :raises ParseError:
     :raises DataError:
@@ -57,4 +61,4 @@ def undeploy(storage: Storage, num_workers: int):
     ast = tosca.load(Path.cwd(), PurePath(service_template))
     template = ast.get_template(inputs)
     topology = template.instantiate(storage)
-    topology.undeploy(num_workers)
+    topology.undeploy(verbose_mode, num_workers)

--- a/src/opera/commands/validate.py
+++ b/src/opera/commands/validate.py
@@ -17,6 +17,10 @@ def add_parser(subparsers):
         "--inputs", "-i", type=argparse.FileType("r"),
         help="YAML file with inputs",
     )
+    parser.add_argument(
+        "--verbose", "-v", action='store_true',
+        help="Turns on verbose mode",
+    )
     parser.add_argument("csar",
                         type=argparse.FileType("r"),
                         help="Cloud service archive file")

--- a/src/opera/instance/base.py
+++ b/src/opera/instance/base.py
@@ -61,9 +61,9 @@ class Base:
         self.set_attribute("state", state)
         self.write()
 
-    def run_operation(self, host, interface, operation):
+    def run_operation(self, host, interface, operation, verbose):
         success, outputs, attributes = self.template.run_operation(
-            host, interface, operation, self,
+            host, interface, operation, self, verbose,
         )
 
         if not success:

--- a/src/opera/instance/node.py
+++ b/src/opera/instance/node.py
@@ -54,39 +54,39 @@ class Node(Base):
         # localhost if nothing suitable is found.
         return self.template.get_host() or "localhost"
 
-    def deploy(self):
+    def deploy(self, verbose):
         thread_utils.print_thread("  Deploying {}".format(self.tosca_id))
 
         self.set_state("creating")
-        self.run_operation("HOST", "Standard", "create")
+        self.run_operation("HOST", "Standard", "create", verbose)
         self.set_state("created")
 
         self.set_state("configuring")
         for requirement in set([r.name for r in self.template.requirements]):
             for relationship in self.out_edges[requirement].values():
                 relationship.run_operation(
-                    "SOURCE", "Configure", "pre_configure_source",
+                    "SOURCE", "Configure", "pre_configure_source", verbose,
                 )
         for requirement_dependants in self.in_edges.values():
             for relationship in requirement_dependants.values():
                 relationship.run_operation(
-                    "TARGET", "Configure", "pre_configure_target",
+                    "TARGET", "Configure", "pre_configure_target", verbose,
                 )
-        self.run_operation("HOST", "Standard", "configure")
+        self.run_operation("HOST", "Standard", "configure", verbose)
         for requirement in set([r.name for r in self.template.requirements]):
             for relationship in self.out_edges[requirement].values():
                 relationship.run_operation(
-                    "SOURCE", "Configure", "post_configure_source",
+                    "SOURCE", "Configure", "post_configure_source", verbose,
                 )
         for requirement_dependants in self.in_edges.values():
             for relationship in requirement_dependants.values():
                 relationship.run_operation(
-                    "TARGET", "Configure", "post_configure_target",
+                    "TARGET", "Configure", "post_configure_target", verbose,
                 )
         self.set_state("configured")
 
         self.set_state("starting")
-        self.run_operation("HOST", "Standard", "start")
+        self.run_operation("HOST", "Standard", "start", verbose)
         self.set_state("started")
 
         # TODO(@tadeboro): Execute various add hooks
@@ -94,15 +94,15 @@ class Node(Base):
             "  Deployment of {} complete".format(self.tosca_id)
         )
 
-    def undeploy(self):
+    def undeploy(self, verbose):
         thread_utils.print_thread("  Undeploying {}".format(self.tosca_id))
 
         self.set_state("stopping")
-        self.run_operation("HOST", "Standard", "stop")
+        self.run_operation("HOST", "Standard", "stop", verbose)
         self.set_state("configured")
 
         self.set_state("deleting")
-        self.run_operation("HOST", "Standard", "delete")
+        self.run_operation("HOST", "Standard", "delete", verbose)
         self.set_state("initial")
 
         # TODO(@tadeboro): Execute various remove hooks

--- a/src/opera/instance/topology.py
+++ b/src/opera/instance/topology.py
@@ -11,7 +11,7 @@ class Topology:
             node.instantiate_relationships()
             node.read()
 
-    def deploy(self, num_workers=None):
+    def deploy(self, verbose, num_workers=None):
         # Currently, we are running a really stupid O(n^3) algorithm, but
         # unless we get to the templates with millions of node instances, we
         # should be fine.
@@ -22,10 +22,11 @@ class Topology:
                     if (not node.deployed
                             and node.ready_for_deploy
                             and executor.not_submitted(node.tosca_id)):
-                        executor.submit_operation(node.deploy, node.tosca_id)
+                        executor.submit_operation(node.deploy, node.tosca_id,
+                                                  verbose)
                 do_deploy = executor.wait_results()
 
-    def undeploy(self, num_workers=None):
+    def undeploy(self, verbose, num_workers=None):
         # Currently, we are running a really stupid O(n^3) algorithm, but
         # unless we get to the templates with millions of node instances, we
         # should be fine.
@@ -36,7 +37,8 @@ class Topology:
                     if (not node.undeployed
                             and node.ready_for_undeploy
                             and executor.not_submitted(node.tosca_id)):
-                        executor.submit_operation(node.undeploy, node.tosca_id)
+                        executor.submit_operation(node.undeploy, node.tosca_id,
+                                                  verbose)
                 do_undeploy = executor.wait_results()
 
     def write(self, data, instance_id):

--- a/src/opera/template/node.py
+++ b/src/opera/template/node.py
@@ -68,10 +68,10 @@ class Node:
 
         return host or "localhost"
 
-    def run_operation(self, host, interface, operation, instance):
+    def run_operation(self, host, interface, operation, instance, verbose):
         operation = self.interfaces[interface].operations.get(operation)
         if operation:
-            return operation.run(host, instance)
+            return operation.run(host, instance, verbose)
         return True, {}, {}
 
     #

--- a/src/opera/template/operation.py
+++ b/src/opera/template/operation.py
@@ -14,7 +14,7 @@ class Operation:
         self.timeout = timeout
         self.host = host
 
-    def run(self, host, instance):
+    def run(self, host, instance, verbose):
         thread_utils.print_thread(
             "    Executing {} on {}".format(self.name, instance.tosca_id)
         )
@@ -40,7 +40,7 @@ class Operation:
         # TODO(@tadeboro): Generalize executors.
         success, ansible_outputs = ansible.run(
             actual_host, str(self.primary),
-            tuple(str(i) for i in self.dependencies), operation_inputs,
+            tuple(str(i) for i in self.dependencies), operation_inputs, verbose
         )
         if not success:
             return False, {}, {}

--- a/src/opera/template/relationship.py
+++ b/src/opera/template/relationship.py
@@ -1,6 +1,7 @@
 from opera.error import DataError
 from opera.instance.relationship import Relationship as Instance
 
+
 class Relationship:
     def __init__(self, name, types, properties, attributes, interfaces):
         self.name = name
@@ -16,10 +17,10 @@ class Relationship:
         relationship_id = "{}--{}".format(source.tosca_id, target.tosca_id)
         return Instance(self, relationship_id, source, target)
 
-    def run_operation(self, host, interface, operation, instance):
+    def run_operation(self, host, interface, operation, instance, verbose):
         operation = self.interfaces[interface].operations.get(operation)
         if operation:
-            return operation.run(host, instance)
+            return operation.run(host, instance, verbose)
         return True, {}, {}
 
     #

--- a/src/opera/threading/node_executor.py
+++ b/src/opera/threading/node_executor.py
@@ -16,9 +16,9 @@ class NodeExecutor(ThreadPoolExecutor):
     def not_submitted(self, node_id):
         return node_id not in self.processed_nodes
 
-    def submit_operation(self, operation, node_id):
+    def submit_operation(self, operation, node_id, verbose):
         self.processed_nodes.add(node_id)
-        self.futures[self.submit(operation)] = node_id
+        self.futures[self.submit(operation, verbose)] = node_id
 
     def wait_results(self):
         proceed = bool(self.futures)


### PR DESCRIPTION
These changes apply to the #68 issue that expressed the need to give
users more information during the orchestration process. And because
less is not always more we decided to implement a debug mode for opera
which returns more information during the deployment/undeployment
process. This could was done by adding a new optional CLI argument
called --verbose or -v which can be used with opera deploy or opera
undeploy CLI commands. We also prepared verbose CLI option for
all the other remaining opera commands.

If the verbose mode is turned on user will be able to see the outputs
of the Ansible playbook executors and also orchestration inputs. This
will hopefully lead to easier debugging of the orchestration process
and especially the actuators of the orchestration.
_______________________________________________________

Now the deploy/un-deploy opera commands would look like these:

```console
# deploy TOSCA template with higher verbosity level
opera deploy -i inputs.yaml service.yaml -v

# undeploy and turn on debug mode
opera undeploy --verbose
```
