### PR TITLE
Add new opera deploy cli command options

### DIFF
--- a/src/opera/commands/deploy.py
+++ b/src/opera/commands/deploy.py
@@ -5,6 +5,7 @@ from pathlib import Path, PurePath
 
 import yaml
 
+from opera.utils import prompt_yes_no_question
 from opera.error import DataError, ParseError
 from opera.parser import tosca
 from opera.storage import Storage
@@ -21,13 +22,28 @@ def add_parser(subparsers):
     )
     parser.add_argument(
         "--inputs", "-i", type=argparse.FileType("r"),
-        help="Optional: YAML file with inputs to override the inputs supplied in init",
+        help="Optional: YAML file with inputs to "
+             "override the inputs supplied in init",
     )
     parser.add_argument(
         "--workers", "-w",
-        help="Maximum number of concurrent deployment \
-            threads (positive number, default 1)",
+        help="Maximum number of concurrent deployment "
+             "threads (positive number, default 1)",
         type=int, default=1
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--resume", "-r", action='store_true',
+        help="Resume the deployment from where it was interrupted",
+    )
+    group.add_argument(
+        "--clean-state", "-c", action='store_true',
+        help="Clean the previous deployment state "
+             "and start over the deployment",
+    )
+    parser.add_argument(
+        "--force", "-f", action='store_true',
+        help="Force the action and skip any possible prompts",
     )
     parser.add_argument(
         "--verbose", "-v", action='store_true',
@@ -42,7 +58,8 @@ def add_parser(subparsers):
 
 def _parser_callback(args):
     if args.instance_path and not path.isdir(args.instance_path):
-        raise argparse.ArgumentTypeError("Directory {0} is not a valid path!".format(args.instance_path))
+        raise argparse.ArgumentTypeError("Directory {0} is not a valid path!"
+                                         .format(args.instance_path))
 
     storage = Storage.create(args.instance_path)
 
@@ -50,15 +67,40 @@ def _parser_callback(args):
         print("{0} is not a positive number!".format(args.workers))
         return 1
 
-    # TODO(@tadeboro): This should be part of the init command that we do not
-    # have yet.
+    delete_existing_state = False
+    if storage.exists("instances"):
+        if args.resume:
+            if not args.force:
+                print("The resume deploy option might have unexpected "
+                      "consequences on the already deployed blueprint.")
+                question = prompt_yes_no_question()
+                if not question:
+                    return 0
+        elif args.clean_state:
+            if args.force:
+                delete_existing_state = True
+            else:
+                print("The clean state deploy option might have unexpected "
+                      "consequences on the already deployed blueprint.")
+                question = prompt_yes_no_question()
+                if question:
+                    delete_existing_state = True
+                else:
+                    return 0
+        else:
+            print("The instance model already exists. Use --resume to "
+                  "continue or --clean-state to delete current deployment "
+                  "state and start over the deployment.")
+            return 0
+
     if args.template:
         service_template = args.template.name
     else:
         if storage.exists("root_file"):
             service_template = storage.read("root_file")
         else:
-            print("CSAR or template root file does not exist. Maybe you have forgotten to initialize it.")
+            print("CSAR or template root file does not exist. "
+                  "Maybe you have forgotten to initialize it.")
             return 1
 
     try:
@@ -71,7 +113,8 @@ def _parser_callback(args):
         return 1
 
     try:
-        deploy(service_template, inputs, storage, args.verbose, args.workers)
+        deploy(service_template, inputs, storage, args.verbose, args.workers,
+               delete_existing_state)
     except ParseError as e:
         print("{}: {}".format(e.loc, e))
         return 1
@@ -82,11 +125,16 @@ def _parser_callback(args):
     return 0
 
 
-def deploy(service_template: str, inputs: typing.Optional[dict], storage: Storage, verbose_mode: bool, num_workers: int):
+def deploy(service_template: str, inputs: typing.Optional[dict],
+           storage: Storage, verbose_mode: bool, num_workers: int,
+           delete_existing_state: bool):
     """
     :raises ParseError:
     :raises DataError:
     """
+    if delete_existing_state:
+        storage.remove("instances")
+
     if inputs is None:
         if storage.exists("inputs"):
             inputs = yaml.safe_load(storage.read("inputs"))

--- a/src/opera/commands/init.py
+++ b/src/opera/commands/init.py
@@ -15,7 +15,8 @@ from opera.storage import Storage
 def add_parser(subparsers):
     parser = subparsers.add_parser(
         "init",
-        help="Initialize the deployment environment for the service template or CSAR"
+        help="Initialize the deployment environment "
+             "for the service template or CSAR"
     )
     parser.add_argument(
         "--instance-path", "-p",
@@ -37,7 +38,8 @@ def add_parser(subparsers):
 
 def _parser_callback(args):
     if args.instance_path and not path.isdir(args.instance_path):
-        raise argparse.ArgumentTypeError("Directory {0} is not a valid path!".format(args.instance_path))
+        raise argparse.ArgumentTypeError("Directory {0} is not a valid path!"
+                                         .format(args.instance_path))
 
     storage = Storage.create(args.instance_path)
 
@@ -67,7 +69,9 @@ def _parser_callback(args):
     return 0
 
 
-def initialize_compressed_csar(csar_name: str, inputs: typing.Optional[dict], storage):
+def initialize_compressed_csar(csar_name: str,
+                               inputs: typing.Optional[dict],
+                               storage: Storage):
     if inputs is None:
         inputs = {}
     storage.write_json(inputs, "inputs")
@@ -91,7 +95,9 @@ def initialize_compressed_csar(csar_name: str, inputs: typing.Optional[dict], st
     template.instantiate(storage)
 
 
-def initialize_service_template(service_template: str, inputs: typing.Optional[dict], storage: Storage):
+def initialize_service_template(service_template: str,
+                                inputs: typing.Optional[dict],
+                                storage: Storage):
     if inputs is None:
         inputs = {}
     storage.write_json(inputs, "inputs")

--- a/src/opera/commands/outputs.py
+++ b/src/opera/commands/outputs.py
@@ -41,7 +41,8 @@ def format_outputs(outputs, format):
 
 def _parser_callback(args):
     if args.instance_path and not path.isdir(args.instance_path):
-        raise argparse.ArgumentTypeError("Directory {0} is not a valid path!".format(args.instance_path))
+        raise argparse.ArgumentTypeError("Directory {0} is not a valid path!"
+                                         .format(args.instance_path))
 
     storage = Storage.create(args.instance_path)
     try:
@@ -66,6 +67,7 @@ def outputs(storage: Storage) -> dict:
 
     ast = tosca.load(Path.cwd(), PurePath(service_template))
     template = ast.get_template(inputs)
-    # We need to instantiate the template in order to get access to the instance state.
+    # We need to instantiate the template in order
+    # to get access to the instance state.
     template.instantiate(storage)
     return template.get_outputs()

--- a/src/opera/commands/undeploy.py
+++ b/src/opera/commands/undeploy.py
@@ -31,7 +31,8 @@ def add_parser(subparsers):
 
 def _parser_callback(args):
     if args.instance_path and not path.isdir(args.instance_path):
-        raise argparse.ArgumentTypeError("Directory {0} is not a valid path!".format(args.instance_path))
+        raise argparse.ArgumentTypeError("Directory {0} is not a valid path!"
+                                         .format(args.instance_path))
 
     if args.workers < 1:
         print("{0} is not a positive number!".format(args.workers))

--- a/src/opera/storage.py
+++ b/src/opera/storage.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+import shutil
 
 
 class Storage:
@@ -31,4 +32,11 @@ class Storage:
 
     def exists(self, *path):
         return (self.path / pathlib.PurePath(*path)).exists()
+
+    def remove(self, *path):
+        if self.exists(*path):
+            shutil.rmtree(self.path / pathlib.PurePath(*path))
+
+    def remove_all(self):
+        shutil.rmtree(self.path)
 

--- a/src/opera/utils.py
+++ b/src/opera/utils.py
@@ -1,0 +1,30 @@
+
+
+def prompt_yes_no_question(yes_responses=("y", "yes"),
+                           no_responses=("n", "no"),
+                           case_sensitive=False,
+                           default_yes_response=True):
+
+    prompt_message = "Do you want to continue? (Y/n): "
+    if not default_yes_response:
+        prompt_message = "Do you want to continue? (y/N): "
+
+    check = str(input(prompt_message)).strip()
+    if not case_sensitive:
+        check = check.lower()
+
+    try:
+        if check == "":
+            return default_yes_response
+        if check in yes_responses:
+            return True
+        elif check in no_responses:
+            return False
+        else:
+            print('Invalid input. Please try again.')
+            return prompt_yes_no_question(yes_responses, no_responses,
+                                          case_sensitive, default_yes_response)
+    except Exception as e:
+        print("Exception occurred: {}. Please enter valid inputs.".format(e))
+        return prompt_yes_no_question(yes_responses, no_responses,
+                                      case_sensitive, default_yes_response)


### PR DESCRIPTION
The discussion in #46 showed that it would be necessary to add some
optional arguments to opera deploy command. In this commit we did just
that in order to address the new features which are:

```console
# deploy (start from the beginning, fail when already deployed)
opera deploy -i inputs.yaml service.yaml

# resume (start from the point of failure)
opera deploy --resume -i inputs.yaml service.yaml

# force (start over)
opera deploy --force -i inputs.yaml service.yaml
```

a) Wise men once said that TOSCA orchestrator should treat each
deployment separately and distinguish it from all other deployments
that have been/would be created before/after. And because opera treats
deployments based on file system storage location (i.e. hidden .opera
folder) we went on and implemented a different deployment behaviour.
So if user tries to deploy again on already deployed instance model an
error is raised telling that deployment has already been done.

b) On the other hand users would often like to continue where they left
or where their deployment process has been interrupted (for example
because of some error in Ansible playbook) and this would then skip all
the instances that have been deployed. To realize that we added
--resume or -r option where user can continue his orchestration.

c) And lastly DevOps engineers would sometimes prefer to re-run the
whole deployment from the starting point without skipping the tasks
that were successfully deployed. For that cases --force or -f optional
CLI argument was introduced which erases the previous instance model
and create a new, fresh one. And to have no worries we ensured that
--resume and --force options are mutually exclusive.
________________________________________________________________

The remaining commit messages in this PR are based on #55 which is ready to be merged. This also means that the changes work when using `opera init` command  before deploying so that user can do `opera deploy {--force|--resume}`.
________________________________________________________________

Resolves #46