### PR TITLE
Add parsing of TOSCA Policy type triggers

### DIFF
--- a/examples/policy_triggers/playbooks/auto_scale.yaml
+++ b/examples/policy_triggers/playbooks/auto_scale.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Autoscale tasks
+      debug:
+        msg: Insert tasks for auto-scaling

--- a/examples/policy_triggers/playbooks/create.yaml
+++ b/examples/policy_triggers/playbooks/create.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: OpenStack tasks
+      debug:
+        msg: Insert OpenStack tasks

--- a/examples/policy_triggers/playbooks/retrieve_info.yaml
+++ b/examples/policy_triggers/playbooks/retrieve_info.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Retrieve info tasks
+      debug:
+        msg: Insert tasks for retrieving info before auto-scaling

--- a/examples/policy_triggers/playbooks/scale_down.yaml
+++ b/examples/policy_triggers/playbooks/scale_down.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Scale down tasks
+      debug:
+        msg: Insert tasks for scaling down

--- a/examples/policy_triggers/playbooks/scale_up.yaml
+++ b/examples/policy_triggers/playbooks/scale_up.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Scale up tasks
+      debug:
+        msg: Insert tasks for scaling up

--- a/examples/policy_triggers/service.yaml
+++ b/examples/policy_triggers/service.yaml
@@ -1,0 +1,211 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  radon.nodes.OpenStack.VM:
+    derived_from: tosca.nodes.Compute
+    attributes:
+      available_instances:
+        type: integer
+        default: 42
+      available_space:
+        type: integer
+        default: 1000
+    properties:
+      name:
+        type: string
+      image:
+        type: string
+      flavor:
+        type: string
+      network:
+        type: string
+      key_name:
+        type: string
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        operations:
+          create:
+            implementation: playbooks/create.yaml
+
+interface_types:
+  radon.interfaces.scaling.ScaleDown:
+    derived_from: tosca.interfaces.Root
+    operations:
+      scale_down:
+        inputs:
+          adjustment: { default: { get_property: [ SELF, name ] } }
+        description: Operation for scaling down.
+        implementation: playbooks/scale_down.yaml
+
+  radon.interfaces.scaling.ScaleUp:
+    derived_from: tosca.interfaces.Root
+    operations:
+      scale_up:
+        inputs:
+          adjustment: { default: { get_property: [ SELF, name ] } }
+        description: Operation for scaling up.
+        implementation: playbooks/scale_up.yaml
+
+  radon.interfaces.scaling.AutoScale:
+    derived_from: tosca.interfaces.Root
+    operations:
+      retrieve_info:
+        description: Operation for autoscaling.
+        implementation: playbooks/retrieve_info.yaml
+      autoscale:
+        description: Operation for autoscaling.
+        implementation: playbooks/auto_scale.yaml
+
+policy_types:
+  radon.policies.scaling.ScaleDown:
+    derived_from: tosca.policies.Scaling
+    properties:
+      cpu_upper_bound:
+        description: The upper bound for the CPU
+        type: float
+        required: false
+        constraints:
+          - less_or_equal: 20.0
+      adjustment:
+        description: The amount by which to scale
+        type: integer
+        required: false
+        constraints:
+          - less_or_equal: -1
+    targets: [ radon.nodes.OpenStack.VM ]
+    triggers:
+      radon.triggers.scaling:
+        description: A trigger for scaling down
+        event: scale_down_trigger
+        target_filter:
+          node: radon.nodes.OpenStack.VM
+        condition:
+          - not:
+            - and:
+              - available_instances: [ { greater: 42 } ]
+              - available_space: [ { greater: 1000 } ]
+        action:
+          - call_operation:
+              operation: radon.interfaces.scaling.ScaleDown.scale_down
+              inputs:
+                adjustment: { get_property: [ SELF, adjustment ] }
+
+  radon.policies.scaling.ScaleUp:
+    derived_from: tosca.policies.Scaling
+    properties:
+      cpu_upper_bound:
+        description: The upper bound for the CPU
+        type: float
+        required: false
+        constraints:
+          - greater_or_equal: 80.0
+      adjustment:
+        description: The amount by which to scale
+        type: integer
+        required: false
+        constraints:
+          - greater_or_equal: 1
+    targets: [ radon.nodes.OpenStack.VM ]
+    triggers:
+      radon.triggers.scaling:
+        description: A trigger for scaling up
+        event: scale_up_trigger
+        target_filter:
+          node: radon.nodes.OpenStack.VM
+        condition:
+          - not:
+            - and:
+              - available_instances: [ { greater: 42 } ]
+              - available_space: [ { greater: 1000 } ]
+        action:
+          - call_operation:
+              operation: radon.interfaces.scaling.ScaleUp.scale_up
+              inputs:
+                adjustment: { get_property: [ SELF, adjustment ] }
+
+  radon.policies.scaling.AutoScale:
+    derived_from: tosca.policies.Scaling
+    properties:
+      min_size:
+        type: integer
+        description: The minimum number of instances
+        required: true
+        status: supported
+        constraints:
+          - greater_or_equal: 1
+      max_size:
+        type: integer
+        description: The maximum number of instances
+        required: true
+        status: supported
+        constraints:
+          - greater_or_equal: 10
+
+topology_template:
+  node_templates:
+    workstation:
+      type: tosca.nodes.Compute
+      attributes:
+        private_address: localhost
+        public_address: localhost
+
+    openstack_vm:
+      type: radon.nodes.OpenStack.VM
+      properties:
+        name: HostVM
+        image: centos7
+        flavor: m1.xsmall
+        network: provider_64_net
+        key_name: my_key
+      requirements:
+        - host: workstation
+      capabilities:
+        host_capability:
+         properties:
+           num_cpus: 1
+           disk_size: 10 GB
+           mem_size: 4096 MB
+
+  policies:
+    scale_down:
+      type: radon.policies.scaling.ScaleDown
+      properties:
+        cpu_upper_bound: 90
+        adjustment: 1
+
+    scale_up:
+      type: radon.policies.scaling.ScaleUp
+      properties:
+        cpu_upper_bound: 90
+        adjustment: 1
+
+    autoscale:
+      type: radon.policies.scaling.AutoScale
+      properties:
+        min_size: 3
+        max_size: 7
+      targets: [ openstack_vm ]
+      triggers:
+        radon.triggers.scaling:
+          description: A trigger for autoscaling
+          event: auto_scale_trigger
+          schedule:
+            start_time: 2020-04-08T21:59:43.10-06:00
+            end_time: 2022-04-08T21:59:43.10-06:00
+          target_filter:
+            node: openstack_vm
+            requirement: workstation
+            capability: host_capability
+          condition:
+            constraint:
+              - not:
+                - and:
+                  - available_instances: [ { greater: 42 } ]
+                  - available_space: [ { greater: 1000 } ]
+            period: 60 sec
+            evaluations: 2
+            method: average
+          action:
+            - call_operation: radon.interfaces.scaling.AutoScale.retrieve_info
+            - call_operation: radon.interfaces.scaling.AutoScale.autoscale

--- a/src/opera/parser/tosca/reference.py
+++ b/src/opera/parser/tosca/reference.py
@@ -46,7 +46,10 @@ class MultipleReferenceWrapper(String):
         target_result = None
         targets = []
         for section_path in self.section_paths:
-            target = service_template.dig(*section_path, self.data)
+            if isinstance(section_path, tuple):
+                target = service_template.dig(*section_path, self.data)
+            else:
+                target = service_template.dig(section_path, self.data)
             if target:
                 path_exists = True
                 targets.append(target)
@@ -60,8 +63,9 @@ class MultipleReferenceWrapper(String):
 
         if not path_exists:
             self.abort("Invalid reference, {} is not in {}".format(
-                str(self.data), str(['/'.join(path_tuple) for path_tuple in self.section_paths])
-            ), self.loc)
+                str(self.data), str(
+                    ['/'.join(path_tuple) if isinstance(path_tuple, tuple) else path_tuple for path_tuple in
+                     self.section_paths])), self.loc)
         return target_result
 
 

--- a/src/opera/parser/tosca/timestamp.py
+++ b/src/opera/parser/tosca/timestamp.py
@@ -1,0 +1,40 @@
+import re
+
+from .string import String
+
+TIMESTAMP_CANONICAL_RE = re.compile(
+    r"""
+    [0-9][0-9][0-9][0-9]
+    -[0-9][0-9]
+    -[0-9][0-9]
+    T[0-9][0-9]
+    :[0-9][0-9]
+    :[0-9][0-9]
+    (\.[0-9]*[1-9])?
+    Z
+    """,
+    re.ASCII | re.VERBOSE,
+)
+
+TIMESTAMP_RE = re.compile(
+    r"""
+     [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]
+    |[0-9][0-9][0-9][0-9]
+     -[0-9][0-9]?
+     -[0-9][0-9]?
+     ([Tt]|[ \t]+)[0-9][0-9]?
+     :[0-9][0-9]
+     :[0-9][0-9]
+     (\.[0-9]*)?
+     (([ \t]*)Z|[-+][0-9][0-9]?(:[0-9][0-9])?)?
+    """,
+    re.ASCII | re.VERBOSE,
+)
+
+
+class Timestamp(String):
+    @classmethod
+    def validate(cls, yaml_node):
+        super().validate(yaml_node)
+        if not TIMESTAMP_CANONICAL_RE.fullmatch(yaml_node.value) and not TIMESTAMP_RE.fullmatch(yaml_node.value):
+            cls.abort("Invalid timestamp format.", yaml_node.loc)

--- a/src/opera/parser/tosca/v_1_3/activity_definition.py
+++ b/src/opera/parser/tosca/v_1_3/activity_definition.py
@@ -1,0 +1,58 @@
+from .parameter_definition import ParameterDefinition
+from ..entity import Entity
+from ..map import Map
+from ..string import String
+from ..void import Void
+
+
+class ActivityDefinition(Entity):
+    ATTRS = dict()
+
+    @classmethod
+    def validate(cls, yaml_node):
+        for key in yaml_node.bare:
+            if key == "delegate":
+                cls.ATTRS = DelegateWorkflowActivityDefinition.ATTRS
+            elif key == "set_state":
+                cls.ATTRS = SetStateActivityDefinition.ATTRS
+            elif key == "call_operation":
+                cls.ATTRS = CallOperationActivityDefinition.ATTRS
+            elif key == "inline":
+                cls.ATTRS = InlineWorkflowActivityDefinition.ATTRS
+            else:
+                cls.abort("Bad activity definition.", yaml_node.loc)
+        super().validate(yaml_node)
+
+
+class DelegateWorkflowActivityDefinition(Entity):
+    ATTRS = dict(
+        delegate=Void,
+        workflow=String,
+        inputs=Map(ParameterDefinition),
+    )
+    REQUIRED = {"delegate"}
+
+
+class SetStateActivityDefinition(Entity):
+    ATTRS = dict(
+        set_state=Void,
+    )
+    REQUIRED = {"set_state"}
+
+
+class CallOperationActivityDefinition(Entity):
+    ATTRS = dict(
+        call_operation=Void,
+        operation=String,
+        inputs=Map(ParameterDefinition),
+    )
+    REQUIRED = {"call_operation"}
+
+
+class InlineWorkflowActivityDefinition(Entity):
+    ATTRS = dict(
+        inline=Void,
+        workflow=String,
+        inputs=Map(ParameterDefinition),
+    )
+    REQUIRED = {"inline"}

--- a/src/opera/parser/tosca/v_1_3/condition_clause_definition.py
+++ b/src/opera/parser/tosca/v_1_3/condition_clause_definition.py
@@ -1,0 +1,26 @@
+from .constraint_clause import ConstraintClause
+from ..entity import Entity
+from ..list import List
+
+
+class ConditionClauseDefinition(Entity):
+    ATTRS = dict()
+    KEYNAMES = {"and", "or", "not"}
+
+    @classmethod
+    def validate(cls, yaml_node):
+        for key in yaml_node.bare:
+            if key in cls.KEYNAMES:
+                cls.ATTRS = {
+                    "and": List(ConditionClauseDefinition),
+                    "or": List(ConditionClauseDefinition),
+                    "not": List(ConditionClauseDefinition),
+                }
+            elif key == "assert":
+                cls.abort("Assert keyname is deprecated. Please use and condition clause instead.", yaml_node.loc)
+            else:
+                if isinstance(yaml_node.bare[key], list):
+                    cls.ATTRS[key] = List(ConstraintClause)
+                else:
+                    cls.ATTRS[key] = ConstraintClause
+        super().validate(yaml_node)

--- a/src/opera/parser/tosca/v_1_3/event_filter_definition.py
+++ b/src/opera/parser/tosca/v_1_3/event_filter_definition.py
@@ -1,0 +1,12 @@
+from ..entity import Entity
+from ..reference import ReferenceXOR
+from ..string import String
+
+
+class EventFilterDefinition(Entity):
+    ATTRS = dict(
+        node=ReferenceXOR(("topology_template", "node_templates"), "node_types"),
+        requirement=String,
+        capability=String,
+    )
+    REQUIRED = {"node"}

--- a/src/opera/parser/tosca/v_1_3/policy_definition.py
+++ b/src/opera/parser/tosca/v_1_3/policy_definition.py
@@ -5,6 +5,8 @@ from ..reference import Reference, ReferenceXOR
 from ..string import String
 from ..void import Void
 
+from .trigger_definition import TriggerDefinition
+
 
 class PolicyDefinition(Entity):
     ATTRS = dict(
@@ -12,10 +14,7 @@ class PolicyDefinition(Entity):
         description=String,
         metadata=Map(String),
         properties=Map(Void),
-        targets=List(ReferenceXOR(("topology_template", "node_templates"), ("topology_template", "groups")))
-        # TODO(@tadeboro): triggers
+        targets=List(ReferenceXOR(("topology_template", "node_templates"), ("topology_template", "groups"))),
+        triggers=Map(TriggerDefinition),
     )
     REQUIRED = {"type"}
-
-    def get_targets(self):
-        return

--- a/src/opera/parser/tosca/v_1_3/policy_type.py
+++ b/src/opera/parser/tosca/v_1_3/policy_type.py
@@ -4,12 +4,13 @@ from ..map import Map
 from ..reference import Reference, ReferenceXOR
 
 from .property_definition import PropertyDefinition
+from .trigger_definition import TriggerDefinition
 
 
 class PolicyType(TypeEntity):
     REFERENCE = Reference("policy_types")
     ATTRS = dict(
         properties=Map(PropertyDefinition),
-        targets=List(ReferenceXOR("node_types", "group_types"))
-        # TODO(@tadeboro): Add triggers
+        targets=List(ReferenceXOR("node_types", "group_types")),
+        triggers=Map(TriggerDefinition)
     )

--- a/src/opera/parser/tosca/v_1_3/time_interval.py
+++ b/src/opera/parser/tosca/v_1_3/time_interval.py
@@ -1,0 +1,10 @@
+from ..entity import Entity
+from ..timestamp import Timestamp
+
+
+class TimeInterval(Entity):
+    ATTRS = dict(
+        start_time=Timestamp,
+        end_time=Timestamp,
+    )
+    REQUIRED = {"start_time", "end_time"}

--- a/src/opera/parser/tosca/v_1_3/trigger_definition.py
+++ b/src/opera/parser/tosca/v_1_3/trigger_definition.py
@@ -1,0 +1,52 @@
+from opera.value import Value
+
+from ..entity import Entity
+from ..string import String
+from ..integer import Integer
+from ..void import Void
+from ..list import List
+from ..type import Type
+
+from .time_interval import TimeInterval
+from .event_filter_definition import EventFilterDefinition
+from .activity_definition import ActivityDefinition
+from .condition_clause_definition import ConditionClauseDefinition
+
+
+class TriggerDefinition(Entity):
+    ATTRS = dict(
+        description=String,
+        event=String,
+        schedule=TimeInterval,
+        target_filter=EventFilterDefinition,
+        condition=List(ConditionClauseDefinition),
+        action=List(ActivityDefinition),
+    )
+    REQUIRED = {"event", "action"}
+
+    @classmethod
+    def validate(cls, yaml_node):
+        if "condition" in yaml_node.bare:
+            condition = yaml_node.bare["condition"]
+            if isinstance(condition, list):
+                pass
+            elif isinstance(condition, dict):
+                cls.ATTRS["condition"] = TriggerExtendedConditionNotation
+            else:
+                cls.abort("Bad policy condition definition.", yaml_node.loc)
+        super().validate(yaml_node)
+
+
+class TriggerExtendedConditionNotation(Entity):
+    ATTRS = dict(
+        constraint=List(ConditionClauseDefinition),
+        period=Void,
+        evaluations=Integer,
+        method=String,
+    )
+
+    @classmethod
+    def validate(cls, yaml_node):
+        if "period" in yaml_node.bare:
+            cls.ATTRS["period"] = Type("scalar-unit.time", yaml_node.loc)
+        super().validate(yaml_node)

--- a/tests/unit/opera/parser/tosca/test_timestamp.py
+++ b/tests/unit/opera/parser/tosca/test_timestamp.py
@@ -1,0 +1,22 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.timestamp import Timestamp
+from opera.parser.yaml.node import Node
+
+
+class TestValidate:
+  @pytest.mark.parametrize("timestamp", [
+      "2001-12-15T02:59:43.1Z", "2001-12-14t21:59:43.10-05:00", "2001-12-15 2:59:43.10",
+      "2002-12-14", "2022-04-08T21:59:43.10-06:00",
+  ])
+  def test_valid_timestamp(self, timestamp):
+      Timestamp.validate(Node(timestamp))
+
+  @pytest.mark.parametrize("timestamp", [
+      "", " ", "trash", "1", "-50", "01.01", "2001-12-15T02:59:43.1ZNJ", "20020-311-31",
+      "2001-12-15 50:590?43.10", "-100-12-15 2:59:43.10", "2020-1l0-05-15T00:00:00Z"
+  ])
+  def test_invalid_timestamp(self, timestamp):
+      with pytest.raises(ParseError, match="timestamp"):
+          Timestamp.validate(Node(timestamp))

--- a/tests/unit/opera/parser/tosca/v_1_3/test_activity_definition.py
+++ b/tests/unit/opera/parser/tosca/v_1_3/test_activity_definition.py
@@ -1,0 +1,61 @@
+from opera.parser.tosca.v_1_3.activity_definition import ActivityDefinition
+
+
+class TestParse:
+    def test_delegate_workflow(self, yaml_ast):
+        ActivityDefinition.parse(yaml_ast(
+            """
+            delegate:
+              workflow: delegate_workflow_name
+              inputs:
+                test_input: { get_input: [ SELF, test_input ] }
+            """
+        ))
+
+    def test_delegate_workflow_short(self, yaml_ast):
+        ActivityDefinition.parse(yaml_ast(
+            """
+            delegate: delegate_workflow_name
+            """
+        ))
+
+    def test_set_state(self, yaml_ast):
+        ActivityDefinition.parse(yaml_ast(
+            """
+            set_state: new_node_state
+            """
+        ))
+
+    def test_call_operation(self, yaml_ast):
+        ActivityDefinition.parse(yaml_ast(
+            """
+            call_operation:
+              operation: my.interfaces.scaling.scale_up
+              inputs:
+                test_input: { get_input: [ SELF, test_input ] }
+            """
+        ))
+
+    def test_call_operation_short(self, yaml_ast):
+        ActivityDefinition.parse(yaml_ast(
+            """
+            call_operation: my.interfaces.scaling.scale_up
+            """
+        ))
+
+    def test_inline_workflow(self, yaml_ast):
+        ActivityDefinition.parse(yaml_ast(
+            """
+            inline:
+              workflow: delegate_workflow_name
+              inputs:
+                test_input: { get_input: [ SELF, test_input ] }
+            """
+        ))
+
+    def test_inline_workflow_short(self, yaml_ast):
+        ActivityDefinition.parse(yaml_ast(
+            """
+            inline: delegate_workflow_name
+            """
+        ))

--- a/tests/unit/opera/parser/tosca/v_1_3/test_condition_clause_definition.py
+++ b/tests/unit/opera/parser/tosca/v_1_3/test_condition_clause_definition.py
@@ -1,0 +1,187 @@
+import pytest
+
+from opera.error import ParseError
+from opera.parser.tosca.v_1_3.condition_clause_definition import ConditionClauseDefinition
+
+
+class TestParseValidate:
+    def test_valid_clause_direct_assertion(self, yaml_ast):
+        test_yaml = yaml_ast(
+            """
+            my_attribute: [ { equal: 42 } ]
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_direct_assertion_list(self, yaml_ast):
+        test_yaml = yaml_ast(
+            """
+            my_attribute: [ { min_length: 1 }, { min_length: 11 } ]
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_not(self, yaml_ast):
+        test_yaml = yaml_ast(
+            """
+            not:
+              - my_attribute: [{equal: my_value}]
+              - my_other_attribute: [{equal: my_other_value}]
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_and(self, yaml_ast):
+        test_yaml = yaml_ast(
+            """
+            and:
+              - my_attribute: [{equal: my_value}]
+              - my_other_attribute: [{equal: my_other_value}]
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_not_and(self, yaml_ast):
+        test_yaml = yaml_ast(
+            """
+            not:
+              - and:
+                - my_attribute: [ { greater_than: 42 } ]
+                - my_other_attribute: [ { less_than: 1000 } ]
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_or(self, yaml_ast):
+        test_yaml = yaml_ast(
+            """
+            or:
+              - my_attribute: [{equal: my_value}]
+              - my_other_attribute: [{equal: my_other_value}]
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_or_not(self, yaml_ast):
+        test_yaml = yaml_ast(
+            """
+            or:
+              - not:
+                - my_attribute1: [{equal: value1}]
+              - not:
+                - my_attribute2: [{equal: value1}]
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_or_and_not(self, yaml_ast):
+        test_yaml = yaml_ast(
+            """
+            or:
+              - and:
+                - protocol: { equal: http }
+                - port: { equal: 80 }
+              - and:
+                - protocol: { equal: https }
+                - port: { equal: 431 }
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_valid_clause_nested(self, yaml_ast):
+        test_yaml = yaml_ast(
+            """
+            or:
+              - not:
+                - my_attribute1: [{equal: value1}]
+              - and:
+                - my_attribute2: { equal: value2 }
+                - and:
+                  - my_attribute3: { equal: value3 }
+                - and:
+                  - my_attribute4: { equal: value4 }
+                  - my_attribute5: { equal: value5 }
+                - or:
+                  - my_attribute6: { equal: value6 }
+                  - my_attribute7: { equal: value7 }
+                  - or:
+                    - not:
+                      - my_attribute8: { equal: value8 }
+                      - my_attribute9: { equal: value9 }
+                    - and:
+                      - not:
+                        - or:
+                          - my_attribute10: { equal: value10 }
+                        - my_attribute11: { equal: value11 }
+              - and:
+                - my_attribute12: { equal: value12 }
+                - my_attribute13: { equal: value13 }
+            """
+        )
+        ConditionClauseDefinition.parse(test_yaml)
+        ConditionClauseDefinition.validate(test_yaml)
+
+    def test_invalid_clause_not(self, yaml_ast):
+        test_yaml = yaml_ast(
+            """
+            nott:
+              - my_attribute: [{equal: my_value}]
+              - my_other_attribute: [{equal: my_other_value}]
+            """
+        )
+        with pytest.raises(ParseError):
+            ConditionClauseDefinition.parse(test_yaml)
+            ConditionClauseDefinition.validate(test_yaml)
+
+    def test_invalid_clause_nested(self, yaml_ast):
+        test_yaml = yaml_ast(
+            """
+            or:
+              - not:
+              - and:
+                - my_attribute2: { equals: value2 }
+                - and:
+                  - my_attribute3: { equal: value3 }
+                - and:
+                  - my_attribute4: { equal: value4 }
+                  - my_attribute5: { equal: value5 }
+                - or:
+                  - my_attribute6: { equal: value6 }
+                  - my_attribute7: { equal: value7 }
+                  - or:
+                    - not:
+                      - my_attribute8: { equal: value8 }
+                      - my_attribute9: { equal: value9 }
+                    - and:
+                      - not:
+                        - or:
+                          - my_attribute10: { equal: value10 }
+                        - my_attribute11: { equal: value11 }
+              - and:
+                - my_attribute12: { equal: value12 }
+                - my_attribute13: { equal: value13 }
+            """
+        )
+        with pytest.raises(ParseError):
+            ConditionClauseDefinition.parse(test_yaml)
+            ConditionClauseDefinition.validate(test_yaml)
+
+    def test_invalid_clause_assert(self, yaml_ast):
+        test_yaml = yaml_ast(
+            """
+            assert:
+              - my_attribute: [{equal: my_value}]
+              - my_other_attribute: [{in_range: [1, 10]}]
+            """
+        )
+        with pytest.raises(ParseError):
+            ConditionClauseDefinition.parse(test_yaml)
+            ConditionClauseDefinition.validate(test_yaml)

--- a/tests/unit/opera/parser/tosca/v_1_3/test_event_filter_definition.py
+++ b/tests/unit/opera/parser/tosca/v_1_3/test_event_filter_definition.py
@@ -1,0 +1,19 @@
+from opera.parser.tosca.v_1_3.event_filter_definition import EventFilterDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        EventFilterDefinition.parse(yaml_ast(
+            """
+            node: node_type_name
+            requirement: requirement_name
+            capability: capability_name
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        EventFilterDefinition.parse(yaml_ast(
+            """
+            node: node_template_name
+            """
+        ))

--- a/tests/unit/opera/parser/tosca/v_1_3/test_policy_definition.py
+++ b/tests/unit/opera/parser/tosca/v_1_3/test_policy_definition.py
@@ -11,6 +11,15 @@ class TestParse:
             properties:
               prop: 6.7
             targets: [node_type_a, node_type_b, node_type_c]
+            triggers:
+              my_first_trigger:
+                event: my_first_trigger
+                action:
+                  - call_operation: test.interfaces.Test1.test2
+              my_second_trigger:
+                event: my_second_trigger
+                action:
+                  - call_operation: test.interfaces.Test2.test1
             """
         ))
 

--- a/tests/unit/opera/parser/tosca/v_1_3/test_policy_type.py
+++ b/tests/unit/opera/parser/tosca/v_1_3/test_policy_type.py
@@ -12,6 +12,35 @@ class TestParse:
             version: "1.2"
             properties: {}
             targets: [ node_type, group_type ]
+            triggers:
+              my_trigger:
+                description: A trigger
+                event: my_trigger
+                schedule:
+                  start_time: 2020-04-08T21:59:43.10-06:00
+                  end_time: 2022-04-08T21:59:43.10-06:00
+                target_filter:
+                  node: node
+                  requirement: my_requirement
+                  capability: my_capability
+                condition:
+                  constraint:
+                    - not:
+                      - and:
+                        - my_attribute: [ in_range: [1, 50] ]
+                        - my_other_attribute: [ equal: my_other_value ]
+                  period: 60 sec
+                  evaluations: 2
+                  method: average
+                action:
+                  - call_operation:
+                      operation: test.interfaces.test.Test.test
+                      inputs:
+                        test_input: { get_property: [ SELF, test_property ] }
+                  - delegate:
+                      workflow: delegate_workflow_name
+                      inputs:
+                        test_input: { get_input: [ SELF, test_input ] }
             """
         ))
 

--- a/tests/unit/opera/parser/tosca/v_1_3/test_time_interval.py
+++ b/tests/unit/opera/parser/tosca/v_1_3/test_time_interval.py
@@ -1,0 +1,11 @@
+from opera.parser.tosca.v_1_3.time_interval import TimeInterval
+
+
+class TestParse:
+    def test_minimal(self, yaml_ast):
+        TimeInterval.parse(yaml_ast(
+            """
+            start_time: 2020-04-08T21:59:43.10-06:00
+            end_time: 2022-04-08T21:59:43.10-06:00
+            """
+        ))

--- a/tests/unit/opera/parser/tosca/v_1_3/test_trigger_definition.py
+++ b/tests/unit/opera/parser/tosca/v_1_3/test_trigger_definition.py
@@ -1,0 +1,39 @@
+from opera.parser.tosca.v_1_3.trigger_definition import TriggerDefinition
+
+
+class TestParse:
+    def test_full(self, yaml_ast):
+        TriggerDefinition.parse(yaml_ast(
+            """
+            description: A trigger
+            event: trigger
+            schedule:
+              start_time: 2020-04-08T21:59:43.10-06:00
+              end_time: 2022-04-08T21:59:43.10-06:00
+            target_filter:
+              node: node
+              requirement: my_requirement
+              capability: my_capability
+            condition:
+              constraint:
+                - not:
+                  - and:
+                    - my_attribute: [{equal: my_value}]
+                    - my_other_attribute: [{equal: my_other_value}]
+              period: 60 sec
+              evaluations: 2
+              method: average
+            action:
+              - call_operation: test.interfaces.Update.update
+              - call_operation: test.interfaces.Upgrade.upgrade
+            """
+        ))
+
+    def test_minimal(self, yaml_ast):
+        TriggerDefinition.parse(yaml_ast(
+            """
+            event: trigger
+            action:
+              - call_operation: test.interfaces.Test.test
+            """
+        ))


### PR DESCRIPTION
The desire for the support of [TOSCA Trigger definitions](https://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.3/os/TOSCA-Simple-Profile-YAML-v1.3-os.html#DEFN_ENTITY_TRIGGER_DEFN) has grown
stronger with opening the #32 issue. At this point we are therefore
introducing the support for parsing TOSCA Policy type triggers which
can be used to define the event, condition and action that is used to
invoke(trigger) a policy it is associated with. These changes also
include unit tests and the runnable TOSCA template example in
`examples/policy_triggers` that contains policies with TOSCA triggers. 
In the implementation part we first targeted to support the standard
trigger definition keynames, but then continued adding the support for
the additional keynames that are used in extended trigger notation.

With these changes we also refactor parsing policy type targets and add
new TOSCA entities like activity, condition clause and event filter, time 
interval etc. along with all the tests and examples.