### PR TITLE
Detect duplicates in the YAML maps

### DIFF
--- a/src/opera/parser/yaml/constructor.py
+++ b/src/opera/parser/yaml/constructor.py
@@ -1,4 +1,5 @@
 from yaml.constructor import BaseConstructor, ConstructorError
+from collections import Counter
 
 from opera.parser.utils.location import Location
 
@@ -56,6 +57,14 @@ class Constructor(BaseConstructor):
         data = Node({}, self._pos(node))
         yield data
         data.value.update(self.construct_mapping(node))
+        counts = Counter(n.bare for n in data.value)
+        duplicates = [k for k, v in counts.items() if v > 1]
+        if duplicates:
+            raise ConstructorError(
+                None, None,
+                "Duplicate map names: {}".format(', '.join(duplicates)),
+                node.start_mark,
+            )
 
     def construct_undefined(self, node):
         raise ConstructorError(

--- a/tests/unit/opera/parser/yaml/test_constructor.py
+++ b/tests/unit/opera/parser/yaml/test_constructor.py
@@ -3,6 +3,7 @@ import math
 import pytest
 from yaml.error import Mark
 from yaml.nodes import MappingNode, ScalarNode, SequenceNode
+from yaml.constructor import ConstructorError
 
 from opera.parser.yaml.constructor import Constructor
 
@@ -138,3 +139,19 @@ class TestNull:
         assert res.loc.line == 9
         assert res.loc.column == 9
         assert res.loc.stream_name == "map"
+
+    def test_construct_map_duplicate(self):
+        mark = Mark(None, None, 8, 8, None, None)
+        children = [
+            (
+                ScalarNode("tag:yaml.org,2002:str", "node1", start_mark=mark),
+                ScalarNode("tag:yaml.org,2002:str", "node1", start_mark=mark),
+            ),
+            (
+                ScalarNode("tag:yaml.org,2002:str", "node1", start_mark=mark),
+                ScalarNode("tag:yaml.org,2002:str", "node1", start_mark=mark),
+            )
+        ]
+        node = MappingNode("tag:yaml.org,2002:map", children, start_mark=mark)
+        with pytest.raises(ConstructorError):
+            res, = Constructor("map").construct_yaml_map(node)


### PR DESCRIPTION
Seeing duplicate map entries in TOSCA YAML templates can be a problem.
This was spotted in #64 where the runnable TOSCA template example with
two node templates having the same names resides. This example showed
that users can be doomed to conceal that one of the duplicates will be
skipped and the orchestration will continue without any error.

With these changes we tackle the aforementioned issue by updating the
YAML parser. We added the duplicate key checks to the YAML map
constructor and also provided the unit test for this issue.

Fixes #64