### PR TITLE
Increase verbosity when encountering unset values

### DIFF
--- a/src/opera/instance/node.py
+++ b/src/opera/instance/node.py
@@ -130,7 +130,7 @@ class Node(Base):
         # TODO(@tadeboro): Add support for nested attribute values once we
         # have data type support.
         if attr in self.attributes:
-            return self.attributes[attr].eval(self)
+            return self.attributes[attr].eval(self, attr)
 
         # Check if there are capability and requirement with the same name.
         if attr in self.out_edges and attr in [c.name for c in

--- a/src/opera/instance/relationship.py
+++ b/src/opera/instance/relationship.py
@@ -30,7 +30,7 @@ class Relationship(Base):
         # have data type support.
         if attr not in self.attributes:
             raise DataError("Instance has no '{}' attribute".format(attr))
-        return self.attributes[attr].eval(self)
+        return self.attributes[attr].eval(self, attr)
 
     def get_property(self, params):
         host, prop, *rest = params

--- a/src/opera/template/node.py
+++ b/src/opera/template/node.py
@@ -58,7 +58,9 @@ class Node:
         ), None)
         if host:
             instance = next(iter(host.instances.values()))
-            return instance.attributes["public_address"].eval(self)
+            return instance.attributes["public_address"].eval(
+                self, "public_address"
+            )
 
         host = next((
             r.target.get_host()
@@ -89,7 +91,7 @@ class Node:
 
         # TODO(@tadeboro): Add support for nested property values.
         if prop in self.properties:
-            return self.properties[prop].eval(self)
+            return self.properties[prop].eval(self, prop)
 
         # Check if there are capability and requirement with the same name.
         if prop in [r.name for r in self.requirements] and prop \

--- a/src/opera/template/operation.py
+++ b/src/opera/template/operation.py
@@ -34,7 +34,7 @@ class Operation:
             actual_host = "localhost"
 
         operation_inputs = {
-            k: v.eval(instance) for k, v in self.inputs.items()
+            k: v.eval(instance, k) for k, v in self.inputs.items()
         }
 
         # TODO(@tadeboro): Generalize executors.

--- a/src/opera/template/relationship.py
+++ b/src/opera/template/relationship.py
@@ -1,6 +1,7 @@
 from opera.error import DataError
 from opera.instance.relationship import Relationship as Instance
 
+
 class Relationship:
     def __init__(self, name, types, properties, attributes, interfaces):
         self.name = name
@@ -39,7 +40,7 @@ class Relationship:
         # have data type support.
         if prop not in self.properties:
             raise DataError("Template has no '{}' property".format(prop))
-        return self.properties[prop].eval(self)
+        return self.properties[prop].eval(self, prop)
 
     def get_input(self, params):
         return self.topology.get_input(params)

--- a/src/opera/template/topology.py
+++ b/src/opera/template/topology.py
@@ -29,7 +29,7 @@ class Topology:
         return {
             k: dict(
                 description=v["description"],
-                value=v["value"].eval(self),
+                value=v["value"].eval(self, "value"),
             ) for k, v in self.outputs.items()
         }
 
@@ -52,7 +52,7 @@ class Topology:
         if params[0] not in self.inputs:
             raise DataError("Invalid input: '{}'".format(params[0]))
 
-        return self.inputs[params[0]].eval(self)
+        return self.inputs[params[0]].eval(self, params[0])
 
     def get_property(self, params):
         node_name, *rest = params

--- a/src/opera/value.py
+++ b/src/opera/value.py
@@ -38,9 +38,9 @@ class Value:
         self._data = None
         self.present = False
 
-    def eval(self, instance):
+    def eval(self, instance, key):
         if not self.present:
-            raise DataError("Cannot use an unset value.")
+            raise DataError("Cannot use an unset value: {}".format(key))
 
         if self.is_function:
             return self.eval_function(instance)


### PR DESCRIPTION
Up until now opera printed "Cannot use an unset value." in case there
was an input defined in the service template but was not set within
inputs.yaml file. There are also other cases for example when you
define a property or attribute within node type without setting its
default value. If you forget to define its value later within the
node_templates section you will get the same error. And since it would
be really useful to know which property/attribute/input causes an issue
in such cases when the data evaluation fails we decided to give more
information to the users by printing also the name of the property.