### PR TITLE
Deploy initialized compressed CSARs from their extracted root

### DIFF
--- a/src/opera/commands/deploy.py
+++ b/src/opera/commands/deploy.py
@@ -1,6 +1,6 @@
 import argparse
 import typing
-from os import path
+from os import chdir, path
 from pathlib import Path, PurePath
 
 import yaml
@@ -143,7 +143,14 @@ def deploy(service_template: str, inputs: typing.Optional[dict],
     storage.write_json(inputs, "inputs")
     storage.write(service_template, "root_file")
 
-    ast = tosca.load(Path.cwd(), PurePath(service_template))
+    if storage.exists("csars"):
+        csar_dir = Path(storage.path) / "csars" / "csar"
+        ast = tosca.load(Path(csar_dir),
+                         PurePath(service_template).relative_to(csar_dir))
+        chdir(csar_dir)
+    else:
+        ast = tosca.load(Path.cwd(), PurePath(service_template))
+
     template = ast.get_template(inputs)
     topology = template.instantiate(storage)
     topology.deploy(verbose_mode, num_workers)

--- a/src/opera/commands/init.py
+++ b/src/opera/commands/init.py
@@ -90,7 +90,7 @@ def initialize_compressed_csar(csar_name: str,
     storage.write(str(csar_tosca_service_template_path), "root_file")
 
     # try to initiate service template from csar
-    ast = tosca.load(Path.cwd(), csar_tosca_service_template_path)
+    ast = tosca.load(Path(csar_dir), Path(tosca_service_template))
     template = ast.get_template(inputs)
     template.instantiate(storage)
 


### PR DESCRIPTION
The support for the compressed CSAR files was introduced along with
opera init command in #55. Currently one CSAR can be initialized within
the same working directory and it gets extracted to .opera/csars/csar.
The orchestration processed including CSAR initialization, deployment
and undeployment worked just fine when the linked artifacts (e.g
Ansible playbooks) for TOSCA operation implementations were deeper in
the structure than the runnable TOSCA service template. However, the
problem has arisen when user wanted to link his playbooks from the root
of the CSAR because opera assumed that the current working directory
that CSAR was deployed from, was at the root of the extracted CSAR ,
Till now opera was searching for the linked files in the current
working dir but not in the actual root of the CSAR (.opera/csars/csar)
which would be necessary. To overcome this issue we have refactored the
opera commands so that opera will use extracted CSAR root storage
folder .opera/csars/csar as the working directory when initializing,
deploying or undeploying compressed CSAR files. The changes we are
applying here are linked with the issue #81 where all this was spotted.