### PR TITLE
Refine required fields in interface and operation inputs

### DIFF
--- a/src/opera/parser/tosca/v_1_3/operation_definition_for_type.py
+++ b/src/opera/parser/tosca/v_1_3/operation_definition_for_type.py
@@ -4,19 +4,18 @@ from ..entity import Entity
 from ..list import List
 from ..map import Map
 from ..string import String
-from ..void import Void
 
 from .operation_implementation_definition import (
     OperationImplementationDefinition,
 )
-from .parameter_definition import ParameterDefinition
+from .property_definition import PropertyDefinition
 
 
 class OperationDefinitionForType(Entity):
     ATTRS = dict(
         description=String,
         implementation=OperationImplementationDefinition,
-        inputs=Map(ParameterDefinition),
+        inputs=Map(PropertyDefinition),
         outputs=Map(List(String)),
     )
 

--- a/tests/integration/misc-tosca-types/modules/node_types/test/test.yaml
+++ b/tests/integration/misc-tosca-types/modules/node_types/test/test.yaml
@@ -24,8 +24,8 @@ node_types:
         operations:
           create:
             inputs:
-              capability_attribute_input: { default: { get_attribute: [ SELF, test_capability, capability_attribute ] } }
-              capability_property_input: { default: { get_property: [ SELF, test_capability, capability_property ] } }
+              capability_attribute_input: { default: { get_attribute: [ SELF, test_capability, capability_attribute ] }, type: string }
+              capability_property_input: { default: { get_property: [ SELF, test_capability, capability_property ] }, type: string }
             implementation:
               primary: playbooks/create.yaml
       test:

--- a/tests/integration/misc-tosca-types/modules/relationship_types/test/test.yaml
+++ b/tests/integration/misc-tosca-types/modules/relationship_types/test/test.yaml
@@ -15,6 +15,7 @@ relationship_types:
             inputs:
               relationship_property:
                 default: { get_property: relationship_property }
+                type: string
             implementation:
               primary: playbooks/test.yaml
 ...


### PR DESCRIPTION
In this commit we are addressing passing information as inputs to
TOSCA Interfaces and Operations which needed some refactoring as it
was stated in #83. When declaring input variables for all operations on
a single interface opera would have returned and error if user had
forgotten to specify type keyname for input. But the same behaviour was
not applied for declaring input variables for a single operation and
opera proceeded with the orchestration if input type had been left out.
With these changes we are replacing Parameter definition with Property
definition which requires type keyname so that opera now also raises an
exception in the second case.