### PR TITLE
Decouple the Python API from CLI interaction.

### DIFF
--- a/src/opera/storage.py
+++ b/src/opera/storage.py
@@ -3,6 +3,12 @@ import pathlib
 
 
 class Storage:
+    DEFAULT_INSTANCE_PATH = ".opera"
+
+    @classmethod
+    def create(cls, instance_path: str = None) -> "Storage":
+        return Storage(pathlib.Path(instance_path or cls.DEFAULT_INSTANCE_PATH))
+
     def __init__(self, path):
         self.path = path
 


### PR DESCRIPTION
This will allow clients, e.g. xopera-api, to use this as a nice Python library. I've extracted the actual logic to separate functions and used a different one for CLI parser callbacks. Much cleaner this way :)