### PR TITLE
Leftover library extraction: state handling

### DIFF
--- a/src/opera/commands/deploy.py
+++ b/src/opera/commands/deploy.py
@@ -49,7 +49,6 @@ def _parser_callback(args):
     # TODO(@tadeboro): This should be part of the init command that we do not
     # have yet.
     if args.template:
-        storage.write(args.template.name, "root_file")
         service_template = args.template.name
     else:
         if storage.exists("root_file"):
@@ -90,6 +89,7 @@ def deploy(service_template: str, inputs: typing.Optional[dict], storage: Storag
         else:
             inputs = {}
     storage.write_json(inputs, "inputs")
+    storage.write(service_template, "root_file")
 
     ast = tosca.load(Path.cwd(), PurePath(service_template))
     template = ast.get_template(inputs)

--- a/src/opera/commands/init.py
+++ b/src/opera/commands/init.py
@@ -48,7 +48,6 @@ def _parser_callback(args):
             initialize_compressed_csar(args.csar.name, inputs, storage)
             print("CSAR was initialized")
         else:
-            storage.write(args.csar.name, "root_file")
             initialize_service_template(args.csar.name, inputs, storage)
             print("Service template was initialized")
     except ParseError as e:
@@ -92,6 +91,7 @@ def initialize_service_template(service_template: str, inputs: typing.Optional[d
     if inputs is None:
         inputs = {}
     storage.write_json(inputs, "inputs")
+    storage.write(service_template, "root_file")
 
     ast = tosca.load(Path.cwd(), PurePath(service_template))
     template = ast.get_template(inputs)


### PR DESCRIPTION
Some state writes were left over in CLI handling functions.

I've tested that this works with xopera-api, so I don't think any further changes will be necessary.