### PR TITLE
Use occurrences keyname to control usage of requirements

### DIFF
--- a/examples/attribute_mapping/service.yaml
+++ b/examples/attribute_mapping/service.yaml
@@ -31,6 +31,7 @@ node_types:
       - student:
           capability: tosca.capabilities.Root
           relationship: steampunk.test.relationships.TeacherTeachesStudent
+          occurrences: [ 0, UNBOUNDED ]
     attributes:
       student_ids:
         type: list

--- a/src/opera/parser/tosca/v_1_3/node_template.py
+++ b/src/opera/parser/tosca/v_1_3/node_template.py
@@ -87,9 +87,12 @@ class NodeTemplate(CollectorMixin, Entity):
                     node_name, name, assignment.node.data,
                 )
 
+            occurrences = definitions[name].get("occurrences")
+
             requirements.append(Requirement(
                 name, assignment.node.data,
                 relationship.get_template(relationship_name, service_ast),
+                occurrences,
             ))
 
         return requirements

--- a/src/opera/parser/tosca/v_1_3/range.py
+++ b/src/opera/parser/tosca/v_1_3/range.py
@@ -9,7 +9,7 @@ from ..base import Base
 #  1. TOSCA's range type is a bit ugly to parse because upper bound can be
 #     string (UNBOUNDED) and should be treated as infinity.
 #  2. Python's bool type subclasses int, which makes isinstance(False, int)
-#     truthy. Thsi is why we have separate checks for bool.
+#     trusty. This is why we have separate checks for bool.
 
 class Range(Base):
     @classmethod

--- a/src/opera/template/node.py
+++ b/src/opera/template/node.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 from opera.error import DataError
 from opera.instance.node import Node as Instance
 from pathlib import Path
@@ -31,7 +33,24 @@ class Node:
         self.instances = None
 
     def resolve_requirements(self, topology):
+        requirement_occurrences = Counter([r.name for r in self.requirements])
         for r in self.requirements:
+            occurrences_range = r.occurrences.data if r.occurrences else None
+            min_occurrences = occurrences_range[0] if occurrences_range else 1
+            max_occurrences = occurrences_range[1] if occurrences_range else 1
+
+            if requirement_occurrences[r.name] < min_occurrences:
+                raise DataError(
+                    "Not enough occurrences found for requirement '{}'. "
+                    "Minimum is: {}".format(
+                        r.name, min_occurrences
+                    ))
+            if requirement_occurrences[r.name] > max_occurrences:
+                raise DataError(
+                    "Too many occurrences found for requirement '{}'. "
+                    "Maximum is: {}".format(
+                        r.name, max_occurrences
+                    ))
             r.resolve(topology)
 
     def is_a(self, typ):

--- a/src/opera/template/requirement.py
+++ b/src/opera/template/requirement.py
@@ -1,9 +1,10 @@
 class Requirement:
-    def __init__(self, name, target_name, relationship):
+    def __init__(self, name, target_name, relationship, occurrences=None):
         self.name = name
         self.target_name = target_name
         self.target = None
         self.relationship = relationship
+        self.occurrences = occurrences
 
     def resolve(self, topology):
         self.target = topology.get_node(self.target_name)

--- a/tests/integration/concurrency/service.yaml
+++ b/tests/integration/concurrency/service.yaml
@@ -134,7 +134,7 @@ topology_template:
         time: "1"
       requirements:
         - host: my-workstation
-        - dependency:  hello-1
-        - dependency:  hello-2
-        - dependency:  hello-7
-        - dependency:  hello-13
+        - dependency1:  hello-1
+        - dependency2:  hello-2
+        - dependency7:  hello-7
+        - dependency13:  hello-13


### PR DESCRIPTION
These changes correspond to issue #88 that has brought up the problem
when targeting more than one instance via the same requirement. When
the same requirement name occurred among the node type/template
requirements opera proceeded with the deployment and the error was
thrown only when running opera outputs that were accessing properties
and attributes via TOSCA functions which already contain checks for
duplicate capability and requirement names. TOSCA standard also states
that duplicate requirement names within the same TOSCA type or template
shall result in error. So now when duplicate requirement name occurs,
opera raises an exception before the deployment.
_______________________________________________________

Closes #88