### PR TITLE
Provide support for the intrinsic TOSCA functions

### DIFF
--- a/examples/intrinsic_functions/service.yaml
+++ b/examples/intrinsic_functions/service.yaml
@@ -1,0 +1,82 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  hello_type_1:
+    derived_from: tosca.nodes.SoftwareComponent
+    attributes:
+      attribute1:
+        type: string
+    properties:
+      property1:
+        type: string
+
+  hello_type_2:
+    attributes:
+      attribute2:
+        type: string
+    properties:
+      property2:
+        type: string
+    derived_from: tosca.nodes.SoftwareComponent
+
+topology_template:
+  inputs:
+    input:
+      type: string
+      default: input
+
+  node_templates:
+    my-workstation:
+      type: tosca.nodes.Compute
+      attributes:
+        private_address: localhost
+        public_address: localhost
+
+    hello1:
+      type: hello_type_1
+      attributes:
+        attribute1: "attribute1"
+      properties:
+        property1: "property1"
+      requirements:
+        - host: my-workstation
+
+    hello2:
+      type: hello_type_2
+      attributes:
+        attribute2: "attribute2"
+      properties:
+        property2: "property2"
+      requirements:
+        - host: my-workstation
+
+  outputs:
+    concat_output:
+      # Result: http://attribute1:property1
+      description: Concatenate string values
+      value: { concat: [ 'http://',
+                       get_attribute: [ hello1, attribute1 ],
+                       ':',
+                       get_property: [ hello1, property1 ] ] }
+    join1_output:
+       # Result: tosca
+      description: Join string values without a delimiter (concat)
+      value: { join: [ [ "t", "o", "s", "c", "a" ] ] }
+    join2_output:
+       # Result: t_o_s_c_a
+      description: Join string values with delimiter
+      value: { join: [ [ "t", "o", "s", "c", "a" ], "_" ] }
+    join3_output:
+       # Result: input, attribute2, property2
+      description: Join string values with delimiter
+      value: { join: [ [ { get_input: input },
+                         { get_attribute: [ hello2, attribute2 ] },
+                         { get_property: [ hello2, property2 ] } ], ", " ] }
+    token1_output:
+       # Result: 111
+      description: Tokenize the string and get the zeroth substring
+      value: { token: [ "111 222 333 444", " ", 0 ] }
+    token2_output:
+       # Result: s
+      description: Tokenize the string and get the second substring
+      value: { token: [ "t-*-o-*-s-*-c-*-a", "-*-", 2 ] }

--- a/src/opera/instance/node.py
+++ b/src/opera/instance/node.py
@@ -187,3 +187,12 @@ class Node(Base):
 
     def get_artifact(self, params):
         return self.template.get_artifact(params)
+
+    def concat(self, params):
+        return self.template.concat(params)
+
+    def join(self, params):
+        return self.template.join(params)
+
+    def token(self, params):
+        return self.template.token(params)

--- a/src/opera/instance/relationship.py
+++ b/src/opera/instance/relationship.py
@@ -77,3 +77,12 @@ class Relationship(Base):
         if host == "TARGET":
             return self.target.get_property(["SELF", prop] + rest)
         return self.template.get_artifact(params)
+
+    def concat(self, params):
+        return self.template.concat(params)
+
+    def join(self, params):
+        return self.template.join(params)
+
+    def token(self, params):
+        return self.template.token(params)

--- a/src/opera/template/node.py
+++ b/src/opera/template/node.py
@@ -188,3 +188,12 @@ class Node:
         if prop in self.artifacts:
             self.artifacts[prop].eval(self)
             return Path(self.artifacts[prop].data).name
+
+    def concat(self, params):
+        return self.topology.concat(params)
+
+    def join(self, params):
+        return self.topology.join(params)
+
+    def token(self, params):
+        return self.topology.token(params)

--- a/src/opera/template/topology.py
+++ b/src/opera/template/topology.py
@@ -68,3 +68,92 @@ class Topology:
         node_name, *rest = params
 
         return self.find_node(node_name).get_artifact(["SELF"] + rest)
+
+    def concat(self, params):
+        if not isinstance(params, list):
+            raise DataError("Concat intrinsic function parameters '{}'"
+                            " should be a list".format(params))
+
+        return self.join([params])
+
+    def join(self, params):
+        if 1 <= len(params) <= 2:
+            if not isinstance(params[0], list):
+                raise DataError("Concat or join intrinsic function parameters "
+                                "'{}' should be a list".format(params))
+
+            string_value_expressions = params[0]
+            delimiter = "" if len(params) == 1 else params[1]
+
+            if not isinstance(delimiter, str):
+                raise DataError(
+                    "Delimiter: '{}' should be a string.".format(delimiter))
+
+            values_to_join = []
+            for param in string_value_expressions:
+                if isinstance(param, dict):
+                    param_dict_keys = list(param.keys())
+                    if len(param_dict_keys) > 1:
+                        raise DataError(
+                            "Dict value expression for concat or join "
+                            "function has too many keys: '{}'".format(param))
+
+                    value_expression_name = param_dict_keys[0]
+                    try:
+                        values_to_join.append(
+                            getattr(self, value_expression_name)(
+                                param[value_expression_name]))
+                    except Exception:
+                        raise DataError(
+                            "Invalid value expression for concat or join "
+                            "function: '{}'".format(value_expression_name))
+                elif isinstance(param, str):
+                    values_to_join.append(param)
+                else:
+                    raise DataError(
+                        "Invalid value for concat or join function function: "
+                        "'{}'".format(param))
+
+            return delimiter.join(values_to_join)
+        else:
+            raise DataError("Too many or too less parameters for: '{}'. Join "
+                            "or concat intrinsic functions can only receive "
+                            "one or two parameters.".format(params))
+
+    def token(self, params):
+        if isinstance(params, list) and len(params) == 3:
+            string_with_tokens = params[0]
+            string_of_token_chars = params[1]
+            substring_index = params[2]
+
+            if not isinstance(string_with_tokens, str):
+                raise DataError(
+                    "String with tokens: '{}' should be a string!".format(
+                        string_with_tokens))
+
+            if not isinstance(string_of_token_chars, str):
+                raise DataError(
+                    "String of token chars: '{}' should be a string!".format(
+                        string_of_token_chars))
+
+            if not isinstance(substring_index, int):
+                raise DataError(
+                    "Substring index: '{}' should be an integer!".format(
+                        substring_index))
+
+            if string_of_token_chars not in string_with_tokens:
+                raise DataError(
+                    "Token: '{}' is not present in string '{}'.".format(
+                        string_of_token_chars, string_with_tokens))
+
+            substrings = string_with_tokens.split(string_of_token_chars)
+
+            if not 0 <= substring_index < len(substrings):
+                raise DataError("Substring index '{}' for token function "
+                                "does not exist.".format(substring_index))
+
+            return substrings[substring_index]
+        else:
+            raise DataError(
+                "Too many or too less parameters for: '{}'. Token intrinsic "
+                "function requires exactly three parameters.".format(params))

--- a/src/opera/value.py
+++ b/src/opera/value.py
@@ -9,6 +9,9 @@ class Value:
         "get_input",
         "get_property",
         "get_artifact",
+        "concat",
+        "join",
+        "token",
     ))
 
     def __init__(self, typ, present, data=None):


### PR DESCRIPTION
Within this commit we are adding the support for TOSCA intrinsic
functions which can be useful when manipulating data in TOSCA
templates. The desire to provide this began with issue #86. Then we
implemented parsing and processing of all three intrinsic functions,
which are concat, join and token along with all their parameters.
There is also an example showing how to use these functions along with
opera outputs that can be found in examples/intrinsic_functions.
__________________________________________________________
cc @dradX, @MysteriousWolf