### PR TITLE
Establish a new CI routine to test the opera examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ commands:
       - common_setup
       - run: make unit_test
       - run: make integration_test
+      - run: make examples_test
 
   run_integration_tests_using_released_opera_version:
     description: Test xOpera CLI commands with testing service template

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,11 @@ integration_test: $(integration_test_scenarios)
 $(integration_test_scenarios):
 	cd $(dir $@) && bash $(notdir $@) $(OPERA)
 
+
+.PHONY: examples_test
+examples_test:
+	cd examples && bash runme.sh $(OPERA)
+
 .PHONY: build
 build:
 	pipenv run python setup.py sdist bdist_wheel

--- a/examples/runme.sh
+++ b/examples/runme.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+# This is the script that is used to test the examples with the CI/CD.
+# You can also run it manually with: ./runme.sh opera
+
+# get opera executable
+opera_executable="$1"
+
+# test an example from ./artifacts
+echo "Testing an example from ./artifacts ..."
+mkdir artifacts/.opera
+$opera_executable deploy --instance-path artifacts/.opera artifacts/service.yaml
+$opera_executable outputs --instance-path artifacts/.opera
+
+# test an example from ./attribute_mapping
+echo "Testing an example from ./attribute_mapping ..."
+mkdir attribute_mapping/.opera
+$opera_executable deploy -p attribute_mapping/.opera attribute_mapping/service.yaml
+$opera_executable outputs -p attribute_mapping/.opera
+
+# test an example from ./capability_attributes_properties
+echo "Testing an example from ./capability_attributes_properties ..."
+mkdir capability_attributes_properties/.opera
+$opera_executable deploy -p capability_attributes_properties/.opera capability_attributes_properties/service.yaml
+$opera_executable outputs -p capability_attributes_properties/.opera
+
+# test an example from ./hello
+echo "Testing an example from ./hello ..."
+mkdir hello/.opera
+$opera_executable deploy -p hello/.opera hello/service.yaml
+$opera_executable undeploy -p hello/.opera
+
+# test an example from ./intrinsic_functions
+echo "Testing an example from ./intrinsic_functions ..."
+mkdir intrinsic_functions/.opera
+$opera_executable deploy -p intrinsic_functions/.opera intrinsic_functions/service.yaml
+$opera_executable outputs -p intrinsic_functions/.opera
+
+# test an example from ./outputs
+echo "Testing an example from ./outputs ..."
+mkdir outputs/.opera
+$opera_executable deploy -p outputs/.opera outputs/service.yaml
+$opera_executable outputs -p intrinsic_functions/.opera
+
+# test an example from ./policy_triggers
+echo "Testing an example from ./policy_triggers ..."
+mkdir policy_triggers/.opera
+$opera_executable deploy -p policy_triggers/.opera policy_triggers/service.yaml
+
+echo "All tests have finished successfully."
+
+# an end-to-end example from ./nginx_openstack cannot be deployed directly
+# with CI/CD because it requires special resources


### PR DESCRIPTION
Where to begin? Tests, examples, more examples in the other repository.
Users can experience a total confusion. But we will not allow this to
happen with opera. That's why we opened #93 issue in order to clean up
the mess and move all the existing opera examples to the integration
test folder. This includes examples in this repository and also the
examples from xopera-examples repository that will not be needed
anymore after this. Since both examples and integration tests contain
runnable TOSCA templates and Ansible playbooks, there is no need to
keep them separated. It would be better to have just the integration
tests so that the features that were currently located only in examples
can be tested within the CI/CD pipelines too. However, it is not that
easy. Some examples require special environments (e.g. OpenStack,
nginx, AWS and so on) to be executed. For these cases we still have a
folder called endtoend_examples.
_______________________
The initial issue: #93