### PR TITLE
Fix documentation deployment errors when having no changes in docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ commands:
           git add .
           git config --global user.email circleci@circleci
           git config --global user.name CircleCI
-          git commit -m "Add generated opera docs for GitHub pages"
+          git commit --allow-empty -m "Add generated opera docs for GitHub pages"
           git push origin gh-pages
 
 executors:


### PR DESCRIPTION
After we supplied the very first opera documentation which followed the
issue #47, we have discovered that there are some issues with the
deployment. The CI/CD pipeline failed when there were no new changes
for the sphinx doc files within the merged commit saying that the
working tree is clean and that there was nothing new to commit. Top
prevent these ugly failures we enabled creating empty commits for these
cases by adding --allow-empty flag to the git commit command.