### PR TITLE
Apply various compressed CSAR deployment fixes

### DIFF
--- a/src/opera/commands/deploy.py
+++ b/src/opera/commands/deploy.py
@@ -143,14 +143,15 @@ def deploy(service_template: str, inputs: typing.Optional[dict],
     storage.write_json(inputs, "inputs")
     storage.write(service_template, "root_file")
 
+    workdir = str(Path.cwd())
     if storage.exists("csars"):
         csar_dir = Path(storage.path) / "csars" / "csar"
+        workdir = str(csar_dir)
         ast = tosca.load(Path(csar_dir),
                          PurePath(service_template).relative_to(csar_dir))
-        chdir(csar_dir)
     else:
         ast = tosca.load(Path.cwd(), PurePath(service_template))
 
     template = ast.get_template(inputs)
     topology = template.instantiate(storage)
-    topology.deploy(verbose_mode, num_workers)
+    topology.deploy(verbose_mode, workdir, num_workers)

--- a/src/opera/commands/outputs.py
+++ b/src/opera/commands/outputs.py
@@ -65,7 +65,13 @@ def outputs(storage: Storage) -> dict:
     service_template = storage.read("root_file")
     inputs = storage.read_json("inputs")
 
-    ast = tosca.load(Path.cwd(), PurePath(service_template))
+    if storage.exists("csars"):
+        csar_dir = Path(storage.path) / "csars" / "csar"
+        ast = tosca.load(Path(csar_dir),
+                         PurePath(service_template).relative_to(csar_dir))
+    else:
+        ast = tosca.load(Path.cwd(), PurePath(service_template))
+
     template = ast.get_template(inputs)
     # We need to instantiate the template in order
     # to get access to the instance state.

--- a/src/opera/commands/undeploy.py
+++ b/src/opera/commands/undeploy.py
@@ -59,14 +59,15 @@ def undeploy(storage: Storage, verbose_mode: bool, num_workers: int):
     service_template = storage.read("root_file")
     inputs = storage.read_json("inputs")
 
+    workdir = str(Path.cwd())
     if storage.exists("csars"):
         csar_dir = Path(storage.path) / "csars" / "csar"
+        workdir = str(csar_dir)
         ast = tosca.load(Path(csar_dir),
                          PurePath(service_template).relative_to(csar_dir))
-        chdir(csar_dir)
     else:
         ast = tosca.load(Path.cwd(), PurePath(service_template))
 
     template = ast.get_template(inputs)
     topology = template.instantiate(storage)
-    topology.undeploy(verbose_mode, num_workers)
+    topology.undeploy(verbose_mode, workdir, num_workers)

--- a/src/opera/executor/ansible.py
+++ b/src/opera/executor/ansible.py
@@ -27,14 +27,16 @@ def _get_inventory(host):
     return yaml.safe_dump(dict(all=dict(hosts=dict(opera=inventory))))
 
 
-def run(host, primary, dependencies, artifacts, vars, verbose):
+def run(host, primary, dependencies, artifacts, vars, verbose, workdir):
     with tempfile.TemporaryDirectory() as dir_path:
         playbook = os.path.join(dir_path, os.path.basename(primary))
-        utils.copy(primary, playbook)
+        utils.copy(os.path.join(workdir, primary), playbook)
         for d in dependencies:
-            utils.copy(d, os.path.join(dir_path, os.path.basename(d)))
+            utils.copy(os.path.join(workdir, d),
+                       os.path.join(dir_path, os.path.basename(d)))
         for a in artifacts:
-            utils.copy(a, os.path.join(dir_path, os.path.basename(a)))
+            utils.copy(os.path.join(workdir, a),
+                       os.path.join(dir_path, os.path.basename(a)))
         inventory = utils.write(
             dir_path, _get_inventory(host), suffix=".yaml",
         )

--- a/src/opera/instance/base.py
+++ b/src/opera/instance/base.py
@@ -61,9 +61,9 @@ class Base:
         self.set_attribute("state", state)
         self.write()
 
-    def run_operation(self, host, interface, operation, verbose):
+    def run_operation(self, host, interface, operation, verbose, workdir):
         success, outputs, attributes = self.template.run_operation(
-            host, interface, operation, self, verbose,
+            host, interface, operation, self, verbose, workdir
         )
 
         if not success:

--- a/src/opera/instance/topology.py
+++ b/src/opera/instance/topology.py
@@ -11,7 +11,7 @@ class Topology:
             node.instantiate_relationships()
             node.read()
 
-    def deploy(self, verbose, num_workers=None):
+    def deploy(self, verbose, workdir, num_workers=None):
         # Currently, we are running a really stupid O(n^3) algorithm, but
         # unless we get to the templates with millions of node instances, we
         # should be fine.
@@ -23,10 +23,10 @@ class Topology:
                             and node.ready_for_deploy
                             and executor.not_submitted(node.tosca_id)):
                         executor.submit_operation(node.deploy, node.tosca_id,
-                                                  verbose)
+                                                  verbose, workdir)
                 do_deploy = executor.wait_results()
 
-    def undeploy(self, verbose, num_workers=None):
+    def undeploy(self, verbose, workdir, num_workers=None):
         # Currently, we are running a really stupid O(n^3) algorithm, but
         # unless we get to the templates with millions of node instances, we
         # should be fine.
@@ -38,7 +38,7 @@ class Topology:
                             and node.ready_for_undeploy
                             and executor.not_submitted(node.tosca_id)):
                         executor.submit_operation(node.undeploy, node.tosca_id,
-                                                  verbose)
+                                                  verbose, workdir)
                 do_undeploy = executor.wait_results()
 
     def write(self, data, instance_id):

--- a/src/opera/parser/tosca/csar.py
+++ b/src/opera/parser/tosca/csar.py
@@ -19,7 +19,8 @@ class CloudServiceArchive:
             ZipFile(self._csar_name, 'r').extractall(tempdir)
 
             try:
-                meta_file_path = Path(tempdir) / "TOSCA-Metadata" / "TOSCA.meta"
+                meta_file_path = Path(
+                    tempdir) / "TOSCA-Metadata" / "TOSCA.meta"
                 if meta_file_path.exists():
                     with meta_file_path.open() as meta_file:
                         self._tosca_meta = yaml.safe_load(meta_file)
@@ -30,10 +31,13 @@ class CloudServiceArchive:
                     self._get_created_by()
                     self._get_other_definitions()
 
-                    # check if 'Entry-Definitions' points to an existing template file in the CSAR
+                    # check if 'Entry-Definitions' points to an existing
+                    # template file in the CSAR
                     if not Path(tempdir).joinpath(template_entry).exists():
-                        raise ParseError('The file "{}" defined within "Entry-Definitions" in '
-                                         '"TOSCA-Metadata/TOSCA.meta" does not exist.'.format(template_entry), self)
+                        raise ParseError(
+                            'The file "{}" defined within "Entry-Definitions" '
+                            'in "TOSCA-Metadata/TOSCA.meta" does not exist.'
+                            .format(template_entry), self)
 
                     return template_entry
                 else:
@@ -44,7 +48,8 @@ class CloudServiceArchive:
 
                     if len(root_yaml_files) != 1:
                         raise ParseError("There should be one root level yaml "
-                                         "file in the root of the CSAR: {}.".format(root_yaml_files), self)
+                                         "file in the root of the CSAR: {}."
+                                         .format(root_yaml_files), self)
 
                     with Path(root_yaml_files[0]).open() as root_template:
                         root_yaml_template = yaml.safe_load(root_template)
@@ -62,20 +67,26 @@ class CloudServiceArchive:
         csar_version = self._tosca_meta.get('CSAR-Version')
         if csar_version and csar_version != 1.1:
             raise ParseError('CSAR-Version entry in the CSAR {} is '
-                             'required to denote version 1.1".'.format(self._csar_name), self)
+                             'required to denote version 1.1".'.format(
+                                self._csar_name), self)
         return csar_version
 
     def _validate_tosca_meta_file_version(self):
-        tosca_meta_file_version = self._tosca_meta.get('TOSCA-Meta-File-Version')
+        tosca_meta_file_version = self._tosca_meta.get(
+            'TOSCA-Meta-File-Version')
         if tosca_meta_file_version and tosca_meta_file_version != 1.1:
-            raise ParseError('TOSCA-Meta-File-Version entry in the CSAR {} is '
-                             'required to denote version 1.1".'.format(self._csar_name), self)
+            raise ParseError(
+                'TOSCA-Meta-File-Version entry in the CSAR {} is '
+                'required to denote version 1.1".'.format(
+                    self._csar_name), self)
         return tosca_meta_file_version
 
     def _get_entry_definitions(self):
         if 'Entry-Definitions' not in self._tosca_meta:
-            raise ParseError('The CSAR "{}" is missing the required metadata "Entry-Definitions" in '
-                             '"TOSCA-Metadata/TOSCA.meta".'.format(self._csar_name), self)
+            raise ParseError(
+                'The CSAR "{}" is missing the required metadata '
+                '"Entry-Definitions" in "TOSCA-Metadata/TOSCA.meta".'.format(
+                    self._csar_name), self)
         return self._tosca_meta.get('Entry-Definitions')
 
     def _get_created_by(self):
@@ -86,14 +97,16 @@ class CloudServiceArchive:
 
     def _get_template_version(self):
         if "template_version" not in self._metadata:
-            raise Exception('The CSAR "{}" is missing the required '
-                            'template_version in metadata".'.format(self._csar_name))
+            raise Exception(
+                'The CSAR "{}" is missing the required '
+                'template_version in metadata".'.format(self._csar_name))
         return self._metadata.get('template_version')
 
     def _get_template_name(self):
         if "template_version" not in self._metadata:
-            raise ParseError('The CSAR "{}" is missing the required'
-                             ' template_name in metadata".'.format(self._csar_name), self)
+            raise ParseError(
+                'The CSAR "{}" is missing the required '
+                'template_name in metadata".'.format(self._csar_name), self)
         return self._metadata.get('template_name')
 
     def _get_author(self):

--- a/src/opera/storage.py
+++ b/src/opera/storage.py
@@ -11,7 +11,7 @@ class Storage:
         return Storage(pathlib.Path(instance_path or cls.DEFAULT_INSTANCE_PATH))
 
     def __init__(self, path):
-        self.path = path
+        self.path = path.absolute()
 
         path.mkdir(exist_ok=True)
 

--- a/src/opera/template/node.py
+++ b/src/opera/template/node.py
@@ -74,10 +74,11 @@ class Node:
 
         return host or "localhost"
 
-    def run_operation(self, host, interface, operation, instance, verbose):
+    def run_operation(self, host, interface, operation, instance, verbose,
+                      workdir):
         operation = self.interfaces[interface].operations.get(operation)
         if operation:
-            return operation.run(host, instance, verbose)
+            return operation.run(host, instance, verbose, workdir)
         return True, {}, {}
 
     #

--- a/src/opera/template/operation.py
+++ b/src/opera/template/operation.py
@@ -14,7 +14,7 @@ class Operation:
         self.timeout = timeout
         self.host = host
 
-    def run(self, host, instance, verbose):
+    def run(self, host, instance, verbose, workdir):
         thread_utils.print_thread(
             "    Executing {} on {}".format(self.name, instance.tosca_id)
         )
@@ -42,6 +42,7 @@ class Operation:
             actual_host, str(self.primary),
             tuple(str(i) for i in self.dependencies),
             tuple(str(i) for i in self.artifacts), operation_inputs, verbose,
+            workdir
         )
         if not success:
             return False, {}, {}

--- a/src/opera/template/relationship.py
+++ b/src/opera/template/relationship.py
@@ -17,10 +17,11 @@ class Relationship:
         relationship_id = "{}--{}".format(source.tosca_id, target.tosca_id)
         return Instance(self, relationship_id, source, target)
 
-    def run_operation(self, host, interface, operation, instance, verbose):
+    def run_operation(self, host, interface, operation, instance, verbose,
+                      workdir):
         operation = self.interfaces[interface].operations.get(operation)
         if operation:
-            return operation.run(host, instance, verbose)
+            return operation.run(host, instance, verbose, workdir)
         return True, {}, {}
 
     #

--- a/src/opera/threading/node_executor.py
+++ b/src/opera/threading/node_executor.py
@@ -16,9 +16,9 @@ class NodeExecutor(ThreadPoolExecutor):
     def not_submitted(self, node_id):
         return node_id not in self.processed_nodes
 
-    def submit_operation(self, operation, node_id, verbose):
+    def submit_operation(self, operation, node_id, verbose, workdir):
         self.processed_nodes.add(node_id)
-        self.futures[self.submit(operation, verbose)] = node_id
+        self.futures[self.submit(operation, verbose, workdir)] = node_id
 
     def wait_results(self):
         proceed = bool(self.futures)

--- a/tests/integration/misc-tosca-types/runme.sh
+++ b/tests/integration/misc-tosca-types/runme.sh
@@ -12,8 +12,15 @@ $opera_executable undeploy
 
 # integration test with compressed CSAR
 rm -rf .opera
+mkdir -p csar-test
 zip -r test.csar service-template.yaml modules TOSCA-Metadata
+mv test.csar csar-test
+mv inputs.yaml csar-test
+cd csar-test
 $opera_executable init -i inputs.yaml test.csar
 $opera_executable deploy
 $opera_executable outputs
 $opera_executable undeploy
+# number of created .opera folders should be 1
+opera_count=$(ls -aR . | grep -c "^\.opera$")
+if [ "$opera_count" -ne 1 ]; then exit 1; fi


### PR DESCRIPTION
There was an idea to introduce the deployment the compressed TOSCA
CSAR. In #82 we made sure that initialized CSARs are deployed from
their extracted root which is usually in .opera/csars/csar (other
storage locations can be used instead of .opera by using
--instance-path CLI flag). That's why we forced opera to move to
the extracted csars storage dir before the deployment. However, we
have forgotten one tiny detail - storage instance files. These are
stored in .opera/instances and accessed during the execution. To
prevent the creation of these files in csars/csar subfolder we
ensured that opera goes two levels up in the storage folder structure.
_______________________

The zipped CSAR this can be tested with is here: [test.zip](https://github.com/xlab-si/xopera-opera/files/5161955/test.zip)


