### PR TITLE
Removal of needless checks for undeclared artifacts

### DIFF
--- a/src/opera/parser/tosca/v_1_3/collector_mixin.py
+++ b/src/opera/parser/tosca/v_1_3/collector_mixin.py
@@ -165,12 +165,6 @@ class CollectorMixin:
         definitions = typ.collect_artifact_definitions(service_ast)
         assignments = self.get("artifacts", {})
 
-        undeclared_artifacts = set(assignments.keys()) - definitions.keys()
-        if undeclared_artifacts:
-            self.abort("Invalid artifacts: {}.".format(
-                ", ".join(undeclared_artifacts),
-            ), self.loc)
-
         return {
             name: (assignments.get(name) or definition).get_value(
                 definition.get_value_type(service_ast),

--- a/tests/integration/misc-tosca-types/service-template.yaml
+++ b/tests/integration/misc-tosca-types/service-template.yaml
@@ -88,6 +88,10 @@ topology_template:
             capability_property: capability_property_value
       requirements:
         - host: my-workstation1
+      artifacts:
+        artifact:
+          type: daily_test.artifacts.test
+          file: modules/node_types/test/file.test
 
   relationship_templates:
     test:


### PR DESCRIPTION
These modifications of code will remove a bug that occurred when there
were different artifact names used in node templates as the ones that
were declared in the corresponding node types. The error also returned
invalid artifacts when there were no artifacts defined in the node
type, but were later added within the node template. Another firm fact
that supports removing these checks is the [TOSCA standard](https://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.3/cos01/TOSCA-Simple-Profile-YAML-v1.3-cos01.html#DEFN_ENTITY_ARTIFACT_DEF) itself, which
defines artifacts keyname within node types or templates as a map of
artifact definitions. This means that there are no artifact assignments
within node types that would need to correspond to artifact definitions
within the node templates.