### PR TITLE
Summon opera info command

### DIFF
--- a/src/opera/commands/__init__.py
+++ b/src/opera/commands/__init__.py
@@ -1,7 +1,8 @@
 from opera.commands import (
-    outputs,
+    validate,
+    init,
+    info,
     deploy,
     undeploy,
-    validate,
-    init
+    outputs
 )

--- a/src/opera/commands/info.py
+++ b/src/opera/commands/info.py
@@ -1,0 +1,99 @@
+import argparse
+import json
+from os import path
+from pathlib import Path, PurePath
+
+import yaml
+
+from opera.error import DataError, ParseError
+from opera.parser import tosca
+from opera.storage import Storage
+
+
+def add_parser(subparsers):
+    parser = subparsers.add_parser(
+        "info",
+        help="Show information about the current project"
+    )
+    parser.add_argument(
+        "--instance-path", "-p",
+        help=".opera storage folder location"
+    )
+    parser.add_argument(
+        "--format", "-f", choices=("yaml", "json"), type=str,
+        default="yaml", help="Output format",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action='store_true',
+        help="Turns on verbose mode",
+    )
+    parser.set_defaults(func=_parser_callback)
+
+
+def format_outputs(info, format):
+    if format == "json":
+        return json.dumps(info, indent=2)
+    if format == "yaml":
+        return yaml.safe_dump(info, default_flow_style=False)
+
+    assert False, "BUG - an invalid format got past the parser"
+
+
+def _parser_callback(args):
+    if args.instance_path and not path.isdir(args.instance_path):
+        raise argparse.ArgumentTypeError("Directory {0} is not a valid path!"
+                                         .format(args.instance_path))
+
+    storage = Storage.create(args.instance_path)
+    try:
+        outs = info(storage)
+        print(format_outputs(outs, args.format))
+    except ParseError as e:
+        print("{}: {}".format(e.loc, e))
+        return 1
+    except DataError as e:
+        print(str(e))
+        return 1
+    return 0
+
+
+def info(storage: Storage) -> dict:
+    """
+    :raises ParseError:
+    :raises DataError:
+    """
+    info_dict = dict(
+        service_template=None,
+        content_root=None,
+        inputs=None,
+        status=None
+    )
+
+    if storage.exists("root_file"):
+        service_template = storage.read("root_file")
+        info_dict["service_template"] = service_template
+
+        if storage.exists("inputs"):
+            info_dict["inputs"] = str(storage.path / "inputs")
+            inputs = yaml.safe_load(storage.read("inputs"))
+        else:
+            inputs = {}
+
+        if storage.exists("csars/csar"):
+            csar_dir = Path(storage.path) / "csars" / "csar"
+            info_dict["content_root"] = str(csar_dir)
+            ast = tosca.load(Path(csar_dir),
+                             PurePath(service_template).relative_to(csar_dir))
+        else:
+            ast = tosca.load(Path.cwd(), PurePath(service_template))
+
+        if storage.exists("instances"):
+            template = ast.get_template(inputs)
+            # We need to instantiate the template in order
+            # to get access to the instance state.
+            topology = template.instantiate(storage)
+            info_dict["status"] = topology.get_info()
+        else:
+            info_dict["status"] = "initialized"
+
+    return info_dict

--- a/src/opera/instance/topology.py
+++ b/src/opera/instance/topology.py
@@ -11,6 +11,15 @@ class Topology:
             node.instantiate_relationships()
             node.read()
 
+    def get_info(self):
+        if all(node.undeployed for node in self.nodes.values()):
+            return "undeployed"
+
+        if all(node.deployed for node in self.nodes.values()):
+            return "deployed"
+
+        return "interrupted"
+
     def deploy(self, verbose, workdir, num_workers=None):
         # Currently, we are running a really stupid O(n^3) algorithm, but
         # unless we get to the templates with millions of node instances, we

--- a/tests/integration/misc-tosca-types/runme.sh
+++ b/tests/integration/misc-tosca-types/runme.sh
@@ -4,11 +4,40 @@ set -euo pipefail
 # get opera executable
 opera_executable="$1"
 
-# perform integration test with service template
+# perform integration test with TOSCA service template
+# test opera info contents before everything
+info_out="$($opera_executable info --format json)"
+test "$(echo "$info_out" | jq -r .status)" = "null"
+
+# validate
 $opera_executable validate -i inputs.yaml service-template.yaml
-$opera_executable deploy -i inputs.yaml service-template.yaml
+# test opera info status after validate
+info_out="$($opera_executable info --format json)"
+test "$(echo "$info_out" | jq -r .status)" = "null"
+
+# init
+$opera_executable init service-template.yaml
+# test opera info status after init
+info_out="$($opera_executable info --format json)"
+test "$(echo "$info_out" | jq -r .status)" = "initialized"
+
+# deploy
+$opera_executable deploy -i inputs.yaml
+# test opera info status after deploy
+info_out="$($opera_executable info --format json)"
+test "$(echo "$info_out" | jq -r .status)" = "deployed"
+
+# outputs
 $opera_executable outputs
+# test opera info status after outputs
+info_out="$($opera_executable info --format json)"
+test "$(echo "$info_out" | jq -r .status)" = "deployed"
+
+# undeploy
 $opera_executable undeploy
+# test opera info status after undeploy
+info_out="$($opera_executable info --format json)"
+test "$(echo "$info_out" | jq -r .status)" = "undeployed"
 
 # integration test with compressed CSAR
 rm -rf .opera
@@ -17,10 +46,15 @@ zip -r test.csar service-template.yaml modules TOSCA-Metadata
 mv test.csar csar-test
 mv inputs.yaml csar-test
 cd csar-test
+$opera_executable info --format yaml
 $opera_executable init -i inputs.yaml test.csar
+$opera_executable info -f json
 $opera_executable deploy
+$opera_executable info -f yaml
 $opera_executable outputs
+$opera_executable info -f json
 $opera_executable undeploy
+$opera_executable info
 # number of created .opera folders should be 1
 opera_count=$(ls -aR . | grep -c "^\.opera$")
 if [ "$opera_count" -ne 1 ]; then exit 1; fi


### PR DESCRIPTION
Within these changes we are bringing a little sunshine. The main
addition is the new opera info command, which is the sixth opera CLI
command in addition to opera validate, init, deploy, undeploy and
outputs. The idea for this command originated from #104, where we
wanted to have an option to inform user about the current opera
project and would allow user to access its storage and state. This
would include printing out the path to TOSCA service template
entrypoint, extracted CSAR location, path to the storage inputs and
status/state of the deployment. The output can be formatted in YAML
or JSON. An example of the latter is shown below.

```json
{
   "service_template":  "string | null",
   "content_root":      "string | null",
   "inputs":            "string | null",
   "status":            "initialized | deployed | undeployed | interrupted | null"
}
```

This commit also includes usage of opera info command within the
integration test scripts to be sure that everything works ok.
_______________________________________________________
cc @cankarm, @sstanovnik 