### PR TITLE
Use all artifacts when accessing them with get_artifact function

### DIFF
--- a/examples/artifacts/files/file.json
+++ b/examples/artifacts/files/file.json
@@ -1,0 +1,3 @@
+{
+  "content": "This is an example JSON file content."
+}

--- a/examples/artifacts/playbooks/create.yaml
+++ b/examples/artifacts/playbooks/create.yaml
@@ -1,14 +1,22 @@
 ---
 - hosts: all
   gather_facts: false
-
   tasks:
-    - name: See what's in that linked file
-      command: "cat {{ file }}"
-      register: file_contents
+    - name: See what's in that linked text file
+      command: "cat {{ text_file_artifact }}"
+      register: text_file_contents
 
-    - name: Set attribute
+    - name: Set text file attribute
       set_stats:
         data:
-          my_attribute: "{{ file_contents.stdout }}"
+          my_text_file_attribute: "{{ text_file_contents.stdout }}"
+
+    - name: See what's in that linked JSON file
+      command: "cat {{ json_file_artifact }}"
+      register: json_file_contents
+
+    - name: Set JSON file attribute
+      set_stats:
+        data:
+          my_json_file_attribute: "{{ json_file_contents.stdout }}"
 ...

--- a/examples/artifacts/service.yaml
+++ b/examples/artifacts/service.yaml
@@ -5,7 +5,15 @@ node_types:
   opera.nodes.file:
     derived_from: tosca.nodes.SoftwareComponent
     attributes:
-      my_attribute:
+      my_text_file_attribute:
+        description: Text file contents
+        type: string
+      my_json_file_attribute:
+        description: JSON file contents
+        type: string
+    properties:
+      json_file:
+        description: JSON file path
         type: string
     interfaces:
       Standard:
@@ -13,10 +21,16 @@ node_types:
           create:
             implementation: playbooks/create.yaml
             inputs:
-              file:
-                default: { get_artifact: [ SELF, file ] }
+              text_file_artifact:
+                description: Text file artifact input
+                type: string
+                default: { get_artifact: [ SELF, text_file ] }
+              json_file_artifact:
+                description: JSON file artifact input
+                type: string
+                default: { get_property: [ SELF, json_file ] }
     artifacts:
-        file:
+        text_file:
           type: tosca.artifacts.File
           file: files/file.txt
 
@@ -24,9 +38,18 @@ topology_template:
   node_templates:
     artifacts_file:
       type: opera.nodes.file
+      properties:
+        json_file: { get_artifact: [ SELF, json_file ] }
+      artifacts:
+          json_file:
+            type: tosca.artifacts.File
+            file: files/file.json
 
   outputs:
-    output_attr:
+    output_attribute_text_file:
       description: Example of attribute output
-      value: { get_attribute: [ artifacts_file, my_attribute ] }
+      value: { get_attribute: [ artifacts_file, my_text_file_attribute ] }
+    output_attribute_json_file:
+      description: Example of attribute output
+      value: { get_attribute: [ artifacts_file, my_json_file_attribute ] }
 ...

--- a/src/opera/parser/tosca/v_1_3/collector_mixin.py
+++ b/src/opera/parser/tosca/v_1_3/collector_mixin.py
@@ -6,7 +6,7 @@ from opera.template.capability import Capability
 class CollectorMixin:
     def collect_types(self, service_ast):
         typ = self.type.resolve_reference(service_ast)
-        return (self.type.data, ) + typ.collect_types(service_ast)
+        return (self.type.data,) + typ.collect_types(service_ast)
 
     def collect_properties(self, service_ast):
         typ = self.type.resolve_reference(service_ast)
@@ -61,7 +61,7 @@ class CollectorMixin:
             defined_operations = definition.get("operations", {})
             assigned_operations = assignment.get("operations", {})
             undeclared_operations = (
-                set(assigned_operations.keys()) - defined_operations.keys()
+                    set(assigned_operations.keys()) - defined_operations.keys()
             )
             if undeclared_operations:
                 self.abort("Undeclared operations: {}.".format(
@@ -117,8 +117,8 @@ class CollectorMixin:
 
                 # Operation implementation details
                 impl = (
-                    op_assignment.get("implementation") or
-                    op_definition.get("implementation")
+                        op_assignment.get("implementation") or
+                        op_definition.get("implementation")
                 )
                 # TODO(@tadeboro): impl can be None here. Fix this.
                 timeout, operation_host = 0, None
@@ -133,7 +133,8 @@ class CollectorMixin:
                     dependencies=[
                         d.file.data for d in impl.get("dependencies", [])
                     ],
-                    artifacts=[a.data for a in self.collect_artifacts(service_ast).values()],
+                    artifacts=[a.data for a in
+                               self.collect_artifacts(service_ast).values()],
                     inputs=inputs,
                     outputs=outputs,
                     timeout=timeout,
@@ -164,6 +165,14 @@ class CollectorMixin:
         typ = self.type.resolve_reference(service_ast)
         definitions = typ.collect_artifact_definitions(service_ast)
         assignments = self.get("artifacts", {})
+
+        duplicate_interfaces = set(assignments.keys()).intersection(
+            definitions.keys())
+        if duplicate_interfaces:
+            for duplicate in duplicate_interfaces:
+                definitions.pop(duplicate)
+
+        definitions.update(assignments)
 
         return {
             name: (assignments.get(name) or definition).get_value(

--- a/src/opera/template/node.py
+++ b/src/opera/template/node.py
@@ -183,14 +183,18 @@ class Node:
             raise DataError("HOST is not yet supported in opera.")
 
         if location == "LOCAL_FILE":
-            raise DataError("Location get_artifact property is not yet supported in opera.")
+            raise DataError("Location get_artifact property is "
+                            "not yet supported in opera.")
 
         if remove:
-            raise DataError("Remove get_artifact property artifacts is not yet supported in opera.")
+            raise DataError("Remove get_artifact property artifacts is "
+                            "not yet supported in opera.")
 
         if prop in self.artifacts:
-            self.artifacts[prop].eval(self)
+            self.artifacts[prop].eval(self, prop)
             return Path(self.artifacts[prop].data).name
+        else:
+            raise DataError("Cannot find artifact '{}'.".format(prop))
 
     def concat(self, params):
         return self.topology.concat(params)


### PR DESCRIPTION
These changes apply mostly to the usage of get_artifact TOSCA function.
Up until now opera used just the artifacts defined within node types
and when addressing them with `get_artifact` everything worked okay.
Fine, right? No, there's more that meets the eye. Artifacts can also be
defined right before the deployment within the node template itself. So
we needed to take those into account too, so that they can be accessed
with `get_artifact` function. Since TOSCA does not specially define
artifact assignments, there is no priority between them. This could
then result in error if user defines the artifact with the same name in
node type and node template. However, TOSCA states that when having
duplicated artifacts, the ones in node template should augment those
that were provided by its declared node type. So this still leaves us
with the idea that we need to prioritize node templates' artifacts. We
have also updated an example in `/examples/artifacts` to test both 
types of artifact definitions.