### PR TITLE
Use node name references with intrinsic functions

### DIFF
--- a/examples/intrinsic_functions/service.yaml
+++ b/examples/intrinsic_functions/service.yaml
@@ -11,13 +11,30 @@ node_types:
         type: string
 
   hello_type_2:
+    derived_from: tosca.nodes.SoftwareComponent
     attributes:
       attribute2:
         type: string
     properties:
       property2:
         type: string
+
+  hello_type_3:
     derived_from: tosca.nodes.SoftwareComponent
+    attributes:
+      attribute3_1:
+        type: string
+      attribute3_2:
+        type: string
+        default: { join: [ [ "a", "t", "t", "r", "i", "b", "u", "t", "e" ] ] }
+    properties:
+      property3_1:
+        type: string
+      property3_2:
+        type: string
+        default: { concat: [ 'Property: ', get_attribute: [ SELF, attribute3_2 ] ] }
+      property3_3:
+        type: string
 
 topology_template:
   inputs:
@@ -50,6 +67,13 @@ topology_template:
       requirements:
         - host: my-workstation
 
+    hello3:
+      type: hello_type_3
+      attributes:
+        attribute3_1: { concat: [ 'Attribute: ', get_property: [ SELF, property3_1 ] ] }
+      properties:
+        property3_1: { token: [ "my_property", "_", 1 ] }
+
   outputs:
     concat_output:
       # Result: http://attribute1:property1
@@ -80,3 +104,17 @@ topology_template:
        # Result: s
       description: Tokenize the string and get the second substring
       value: { token: [ "t-*-o-*-s-*-c-*-a", "-*-", 2 ] }
+    attribute:
+      # Result: Attribute: property
+      description: Attribute value
+      value: { get_attribute: [ hello3, attribute3_1 ] }
+    property:
+      # Result: Property: attribute
+      description: Property value
+      value: { get_property: [ hello3, property3_2 ] }
+    properties:
+      # Result: Properties: property1 property2 property
+      description: Joined properties
+      value: { join: [[ 'Properties:', { get_property: [ hello1, property1 ] },
+                                        { get_property: [ hello2, property2 ] },
+                                        { get_property: [ hello3, property3_1 ] } ], " " ] }

--- a/src/opera/template/node.py
+++ b/src/opera/template/node.py
@@ -197,10 +197,10 @@ class Node:
             raise DataError("Cannot find artifact '{}'.".format(prop))
 
     def concat(self, params):
-        return self.topology.concat(params)
+        return self.topology.concat(params, self)
 
     def join(self, params):
-        return self.topology.join(params)
+        return self.topology.join(params, self)
 
     def token(self, params):
         return self.topology.token(params)

--- a/src/opera/template/topology.py
+++ b/src/opera/template/topology.py
@@ -69,14 +69,14 @@ class Topology:
 
         return self.find_node(node_name).get_artifact(["SELF"] + rest)
 
-    def concat(self, params):
+    def concat(self, params, node=None):
         if not isinstance(params, list):
             raise DataError("Concat intrinsic function parameters '{}'"
                             " should be a list".format(params))
 
-        return self.join([params])
+        return self.join([params], node)
 
-    def join(self, params):
+    def join(self, params, node=None):
         if 1 <= len(params) <= 2:
             if not isinstance(params[0], list):
                 raise DataError("Concat or join intrinsic function parameters "
@@ -100,8 +100,9 @@ class Topology:
 
                     value_expression_name = param_dict_keys[0]
                     try:
+                        entity = node if node else self
                         values_to_join.append(
-                            getattr(self, value_expression_name)(
+                            getattr(entity, value_expression_name)(
                                 param[value_expression_name]))
                     except Exception:
                         raise DataError(


### PR DESCRIPTION
In this commit we apply some refactorings to TOSCA instrinsic functions
based on the problems spotted in #112. There it was discovered that
SELF keyword in TOSCA functions do not work when using them inside
intrinsic functions. Or in other words, we are unable to get node's own
attributes and properties from intrinsic functions used within this
node. The problem originates from the part where we have forgotten that
we the intrinsic functions will not be used only in template's outputs,
but also throughout the whole TOSCA template. Therefore this was
calling for a change where we made sure that node names and their
references are used when calling other TOSCA functions in intrinsic
functions. This does mostly concern concat and join functions as those
two are allowed to have other function calls (e.g. get_attribute,
get_property, get_input) within their list of string value expressions.
Token function is not included because it can operate on strings only.
______

cc @mihaTrajbaric, @dradx

Closes #112.