### PR TITLE
Fix policies serialization and refactor examples

### DIFF
--- a/examples/attribute_mapping/service.yaml
+++ b/examples/attribute_mapping/service.yaml
@@ -20,7 +20,7 @@ node_types:
         operations:
           create:
             inputs:
-              id: { default: { get_property: [ SELF, enrolment_number ] } }
+              id: { default: { get_property: [ SELF, enrolment_number ] }, type: integer }
             outputs:
               student_id: [ SELF, student_id ]
             implementation: playbooks/create-student.yaml
@@ -51,8 +51,10 @@ relationship_types:
             inputs:
               student_id:
                 default: { get_attribute: [ TARGET, student_id ] }
+                type: string
               student_ids:
                 default: { get_attribute: [ SOURCE, student_ids ] }
+                type: list
             outputs:
               new_list: [ SOURCE, student_ids ]
             implementation: playbooks/teacher-teaches-student--preconfigure-source.yaml

--- a/examples/nginx_openstack/library/nginx/server/types.yaml
+++ b/examples/nginx_openstack/library/nginx/server/types.yaml
@@ -22,7 +22,6 @@ node_types:
             implementation:
               primary: playbooks/uninstall.yaml
 
-
 relationship_types:
   my.relationships.NginxSiteHosting:
     derived_from: tosca.relationships.HostedOn
@@ -33,5 +32,6 @@ relationship_types:
             inputs:
               marker:
                 default: { get_attribute: [ TARGET, host, id ] }
+                type: string
             implementation:
               primary: playbooks/reload.yaml

--- a/examples/nginx_openstack/library/openstack/vm/types.yaml
+++ b/examples/nginx_openstack/library/openstack/vm/types.yaml
@@ -34,15 +34,16 @@ node_types:
         operations:
           create:
             inputs:
-              vm_name:  { default: { get_property: [ SELF, name     ] } }
-              image:    { default: { get_property: [ SELF, image    ] } }
-              flavor:   { default: { get_property: [ SELF, flavor   ] } }
-              network:  { default: { get_property: [ SELF, network  ] } }
-              key_name: { default: { get_property: [ SELF, key_name ] } }
+              vm_name:  { default: { get_property: [ SELF, name     ] }, type: string }
+              image:    { default: { get_property: [ SELF, image    ] }, type: string }
+              flavor:   { default: { get_property: [ SELF, flavor   ] }, type: string }
+              network:  { default: { get_property: [ SELF, network  ] }, type: string }
+              key_name: { default: { get_property: [ SELF, key_name ] }, type: string }
               security_groups:
-                default: { get_property: [ SELF, security_groups  ] }
+                default: { get_property: [ SELF, security_groups ] }
+                type: string
             implementation: playbooks/create.yaml
           delete:
             inputs:
-              id: { default: { get_attribute: [ SELF, id ] } }
+              id: { default: { get_attribute: [ SELF, id ] }, type: string }
             implementation: playbooks/delete.yaml

--- a/examples/policy_triggers/service.yaml
+++ b/examples/policy_triggers/service.yaml
@@ -34,7 +34,7 @@ interface_types:
     operations:
       scale_down:
         inputs:
-          adjustment: { default: { get_property: [ SELF, name ] } }
+          adjustment: { default: 0, type: integer }
         description: Operation for scaling down.
         implementation: playbooks/scale_down.yaml
 
@@ -43,7 +43,7 @@ interface_types:
     operations:
       scale_up:
         inputs:
-          adjustment: { default: { get_property: [ SELF, name ] } }
+          adjustment: { default: 1, type: integer }
         description: Operation for scaling up.
         implementation: playbooks/scale_up.yaml
 
@@ -83,8 +83,8 @@ policy_types:
         condition:
           - not:
             - and:
-              - available_instances: [ { greater: 42 } ]
-              - available_space: [ { greater: 1000 } ]
+              - available_instances: [ { greater_than: 42 } ]
+              - available_space: [ { greater_than: 1000 } ]
         action:
           - call_operation:
               operation: radon.interfaces.scaling.ScaleDown.scale_down
@@ -116,8 +116,8 @@ policy_types:
         condition:
           - not:
             - and:
-              - available_instances: [ { greater: 42 } ]
-              - available_space: [ { greater: 1000 } ]
+              - available_instances: [ { greater_than: 42 } ]
+              - available_space: [ { greater_than: 1000 } ]
         action:
           - call_operation:
               operation: radon.interfaces.scaling.ScaleUp.scale_up
@@ -160,12 +160,6 @@ topology_template:
         key_name: my_key
       requirements:
         - host: workstation
-      capabilities:
-        host_capability:
-         properties:
-           num_cpus: 1
-           disk_size: 10 GB
-           mem_size: 4096 MB
 
   policies:
     scale_down:
@@ -201,8 +195,8 @@ topology_template:
             constraint:
               - not:
                 - and:
-                  - available_instances: [ { greater: 42 } ]
-                  - available_space: [ { greater: 1000 } ]
+                  - available_instances: [ { greater_than: 42 } ]
+                  - available_space: [ { greater_than: 1000 } ]
             period: 60 sec
             evaluations: 2
             method: average

--- a/examples/policy_triggers/service.yaml
+++ b/examples/policy_triggers/service.yaml
@@ -34,7 +34,7 @@ interface_types:
     operations:
       scale_down:
         inputs:
-          adjustment: { default: 0, type: integer }
+          adjustment: { default: 1, type: integer }
         description: Operation for scaling down.
         implementation: playbooks/scale_down.yaml
 
@@ -162,44 +162,44 @@ topology_template:
         - host: workstation
 
   policies:
-    scale_down:
-      type: radon.policies.scaling.ScaleDown
-      properties:
-        cpu_upper_bound: 90
-        adjustment: 1
+    - scale_down:
+        type: radon.policies.scaling.ScaleDown
+        properties:
+          cpu_upper_bound: 90
+          adjustment: 1
 
-    scale_up:
-      type: radon.policies.scaling.ScaleUp
-      properties:
-        cpu_upper_bound: 90
-        adjustment: 1
+    - scale_up:
+        type: radon.policies.scaling.ScaleUp
+        properties:
+          cpu_upper_bound: 90
+          adjustment: 1
 
-    autoscale:
-      type: radon.policies.scaling.AutoScale
-      properties:
-        min_size: 3
-        max_size: 7
-      targets: [ openstack_vm ]
-      triggers:
-        radon.triggers.scaling:
-          description: A trigger for autoscaling
-          event: auto_scale_trigger
-          schedule:
-            start_time: 2020-04-08T21:59:43.10-06:00
-            end_time: 2022-04-08T21:59:43.10-06:00
-          target_filter:
-            node: openstack_vm
-            requirement: workstation
-            capability: host_capability
-          condition:
-            constraint:
-              - not:
-                - and:
-                  - available_instances: [ { greater_than: 42 } ]
-                  - available_space: [ { greater_than: 1000 } ]
-            period: 60 sec
-            evaluations: 2
-            method: average
-          action:
-            - call_operation: radon.interfaces.scaling.AutoScale.retrieve_info
-            - call_operation: radon.interfaces.scaling.AutoScale.autoscale
+    - autoscale:
+        type: radon.policies.scaling.AutoScale
+        properties:
+          min_size: 3
+          max_size: 7
+        targets: [ openstack_vm ]
+        triggers:
+          radon.triggers.scaling:
+            description: A trigger for autoscaling
+            event: auto_scale_trigger
+            schedule:
+              start_time: 2020-04-08T21:59:43.10-06:00
+              end_time: 2022-04-08T21:59:43.10-06:00
+            target_filter:
+              node: openstack_vm
+              requirement: workstation
+              capability: host_capability
+            condition:
+              constraint:
+                - not:
+                  - and:
+                    - available_instances: [ { greater_than: 42 } ]
+                    - available_space: [ { greater_than: 1000 } ]
+              period: 60 sec
+              evaluations: 2
+              method: average
+            action:
+              - call_operation: radon.interfaces.scaling.AutoScale.retrieve_info
+              - call_operation: radon.interfaces.scaling.AutoScale.autoscale

--- a/src/opera/parser/tosca/v_1_3/topology_template.py
+++ b/src/opera/parser/tosca/v_1_3/topology_template.py
@@ -3,6 +3,7 @@ from opera.template.topology import Topology
 
 from ..entity import Entity
 from ..map import Map
+from ..list import List
 from ..string import String
 
 from .group_definition import GroupDefinition
@@ -19,7 +20,7 @@ class TopologyTemplate(Entity):
         node_templates=Map(NodeTemplate),
         relationship_templates=Map(RelationshipTemplate),
         groups=Map(GroupDefinition),
-        policies=Map(PolicyDefinition),
+        policies=List(Map(PolicyDefinition)),
         outputs=Map(ParameterDefinition),
         # TODO(@tadeboro): substitution_mappings and workflows
     )

--- a/tests/integration/misc-tosca-types/service-template.yaml
+++ b/tests/integration/misc-tosca-types/service-template.yaml
@@ -105,11 +105,11 @@ topology_template:
       members: [ my-workstation1, my-workstation2 ]
 
   policies:
-    test:
-      type: daily_test_policies.test
-      properties:
-        test_id: *test
-      targets: [ hello, setter, workstation_group ]
+    - test:
+        type: daily_test_policies.test
+        properties:
+          test_id: *test
+        targets: [ hello, setter, workstation_group ]
 
   outputs:
     output_prop:

--- a/tests/unit/opera/parser/tosca/v_1_3/test_topology_template.py
+++ b/tests/unit/opera/parser/tosca/v_1_3/test_topology_template.py
@@ -20,8 +20,8 @@ class TestParse:
               my_group:
                 type: group.type
             policies:
-              my_policy:
-                type: policy.type
+              - my_policy:
+                  type: policy.type
             outputs:
               my_output:
                 type: string


### PR DESCRIPTION
These significant changes are directly connected to the issue #115. To
sum things up, here we changed the parsing of the TOSCA policies for
the topology_template section. Before this commit, policies were parsed
and represented as a map/dict and after looking at the TOSCA standard,
we soon have found out that we should have used a list. So the TOSCA
parser within the orchestrator was refactored to the point that it
serializes policies as a list. By making this change we also had to
refactor some examples and integration tests.

There is also an additional commit for updating the examples.
________________

Fixes #115.

Connected to https://github.com/radon-h2020/radon-particles/pull/62