### PR TITLE
Relationship types and templates fixes for inputs and outputs

### DIFF
--- a/examples/relationship_outputs/files/file.txt
+++ b/examples/relationship_outputs/files/file.txt
@@ -1,0 +1,1 @@
+This is an example file content.

--- a/examples/relationship_outputs/playbooks/create.yaml
+++ b/examples/relationship_outputs/playbooks/create.yaml
@@ -1,0 +1,12 @@
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say create
+      debug:
+        msg: "create"
+
+    - name: Set node attribute
+      set_stats:
+        data:
+          node_attribute: "Node attribute"

--- a/examples/relationship_outputs/playbooks/post_configure_source.yaml
+++ b/examples/relationship_outputs/playbooks/post_configure_source.yaml
@@ -1,0 +1,43 @@
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say post_configure_source
+      debug:
+        msg: "post_configure_source"
+
+    - name: Print out the value of relationship_attribute
+      debug:
+        msg: "{{ relationship_attribute }}"
+
+    - name: Print out the value of relationship_property
+      debug:
+        msg: "{{ relationship_property }}"
+
+    - name: Print out the value of relationship_input
+      debug:
+        msg: "{{ relationship_input }}"
+
+    - name: Set attribute
+      set_stats:
+        data:
+          post_configure_source_attribute: "{{ relationship_attribute }}"
+
+    - name: Set attribute
+      set_stats:
+        data:
+          post_configure_source_property_attribute: "{{ relationship_property }}"
+
+    - name: Set attribute
+      set_stats:
+        data:
+          post_configure_source_input_attribute: "{{ relationship_input }}"
+
+    - name: See what lies in that dependecy text file
+      command: "cat file.txt"
+      register: text_file_contents
+
+    - name: Set text file attribute
+      set_stats:
+        data:
+          post_configure_source_txt_file_attribute: "{{ text_file_contents.stdout }}"

--- a/examples/relationship_outputs/playbooks/post_configure_target.yaml
+++ b/examples/relationship_outputs/playbooks/post_configure_target.yaml
@@ -1,0 +1,12 @@
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say post_configure_target
+      debug:
+        msg: "post_configure_target"
+
+    - name: Set attribute
+      set_stats:
+        data:
+          post_configure_target_attribute: "This is post configure target attribute"

--- a/examples/relationship_outputs/playbooks/pre_configure_source.yaml
+++ b/examples/relationship_outputs/playbooks/pre_configure_source.yaml
@@ -1,0 +1,12 @@
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say pre_configure_source
+      debug:
+        msg: "pre_configure_source"
+
+    - name: Set attribute
+      set_stats:
+        data:
+          pre_configure_source_attribute: "This is pre configure source attribute"

--- a/examples/relationship_outputs/playbooks/pre_configure_target.yaml
+++ b/examples/relationship_outputs/playbooks/pre_configure_target.yaml
@@ -1,0 +1,12 @@
+- hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: Say pre_configure_target
+      debug:
+        msg: "pre_configure_target"
+
+    - name: Set attribute
+      set_stats:
+        data:
+          pre_configure_target_attribute: "This is pre configure target attribute"

--- a/examples/relationship_outputs/service.yaml
+++ b/examples/relationship_outputs/service.yaml
@@ -1,0 +1,149 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  radon.nodes.test:
+    derived_from: tosca.nodes.Compute
+    attributes:
+      node_attribute:
+        type: string
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        operations:
+          create: playbooks/create.yaml
+    requirements:
+      - host:
+          capability: tosca.capabilities.Compute
+          relationship: radon.relationships.test
+
+relationship_types:
+  radon.relationships.test:
+    derived_from: tosca.relationships.HostedOn
+    attributes:
+      relationship_attribute:
+        type: string
+        default: Default relationship attribute
+      pre_configure_source_attribute:
+        description: Attribute set by pre_configure_source interface operation
+        type: string
+      pre_configure_target_attribute:
+        description: Attribute set by pre_configure_target interface operation
+        type: string
+      post_configure_source_attribute:
+        description: >
+          Attribute set by post_configure_source interface operation from the
+          relationship_attribute attribute that enters as an operation input
+        type: string
+      post_configure_source_property_attribute:
+        description: >
+          Attribute set by post_configure_source interface operation from the
+          relationship_property property that enters as an operation input
+        type: string
+      post_configure_source_input_attribute:
+        description: >
+          Attribute set by post_configure_source interface operation from the
+          relationship_input input that enters as an operation input
+        type: string
+      post_configure_source_txt_file_attribute:
+        description: >
+          Attribute set by post_configure_source interface operation that
+          includes the contents of the dependent txt file
+        type: string
+      post_configure_target_attribute:
+        description: Attribute set by post_configure_target interface operation
+        type: string
+    properties:
+      relationship_property:
+        type: string
+        default: Default relationship property
+    interfaces:
+      Configure:
+        operations:
+          pre_configure_source:
+            implementation: playbooks/pre_configure_source.yaml
+          pre_configure_target:
+            implementation: playbooks/pre_configure_target.yaml
+          post_configure_source:
+            inputs:
+              relationship_attribute:
+                type: string
+                default: { get_attribute: [ SELF, relationship_attribute ] }
+              relationship_property:
+                type: string
+                default: { get_property: [ SELF, relationship_property ] }
+              relationship_input:
+                type: string
+                default: { get_input: relationship_input }
+            implementation:
+              primary: playbooks/post_configure_source.yaml
+              dependencies:
+                - files/file.txt
+          post_configure_target:
+            implementation: playbooks/post_configure_target.yaml
+
+topology_template:
+  inputs:
+    host_ip:
+      type: string
+      default: localhost
+    relationship_input:
+      type: string
+      default: Relationship input
+
+  node_templates:
+    my_workstation:
+      type: tosca.nodes.Compute
+      attributes:
+        private_address: { get_input: host_ip }
+        public_address: { get_input: host_ip }
+
+    test_node:
+      type: radon.nodes.test
+      requirements:
+        - host:
+            node: my_workstation
+            relationship: test_relationship
+
+  relationship_templates:
+    test_relationship:
+      type: radon.relationships.test
+      attributes:
+        relationship_attribute: Relationship attribute
+      properties:
+        relationship_property: Relationship property
+
+  outputs:
+    output_node_attribute:
+      description: Node attribute output
+      value: { get_attribute: [ test_node, node_attribute ] }
+    output_relationship_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, relationship_attribute ] }
+    output_relationship_property:
+      description: Relationship property output
+      value: { get_property: [ test_relationship, relationship_property ] }
+    output_relationship_input:
+      description: Relationship input output
+      value: { get_input: relationship_input }
+    output_pre_configure_source_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, pre_configure_source_attribute ] }
+    output_pre_configure_target_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, pre_configure_target_attribute ] }
+    output_post_configure_source_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, post_configure_source_attribute ] }
+    output_post_configure_source_property_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, post_configure_source_property_attribute ] }
+    output_post_configure_source_input_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, post_configure_source_input_attribute ] }
+    output_post_configure_source_txt_file_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, post_configure_source_txt_file_attribute ] }
+    output_post_configure_target_attribute:
+      description: Relationship attribute output
+      value: { get_attribute: [ test_relationship, post_configure_target_attribute ] }
+...

--- a/examples/runme.sh
+++ b/examples/runme.sh
@@ -48,6 +48,12 @@ echo "Testing an example from ./policy_triggers ..."
 mkdir policy_triggers/.opera
 $opera_executable deploy -p policy_triggers/.opera policy_triggers/service.yaml
 
+# test an example from ./relationship_outputs
+echo "Testing an example from ./relationship_outputs ..."
+mkdir relationship_outputs/.opera
+$opera_executable deploy -p relationship_outputs/.opera relationship_outputs/service.yaml
+$opera_executable outputs -p relationship_outputs/.opera
+
 echo "All tests have finished successfully."
 
 # an end-to-end example from ./nginx_openstack cannot be deployed directly

--- a/src/opera/instance/base.py
+++ b/src/opera/instance/base.py
@@ -70,7 +70,7 @@ class Base:
             raise OperationError("Failed")
 
         for params, value in outputs:
-            self.map_attribute(params, value)
+            self.template.map_attribute(params, value)
         self.update_attributes(attributes)
         self.write()
 

--- a/src/opera/instance/node.py
+++ b/src/opera/instance/node.py
@@ -20,10 +20,13 @@ class Node(Base):
             for target in requirement.target.instances.values():
                 target.in_edges[rname] = target.in_edges.get(rname, {})
 
-                rel = requirement.relationship.instantiate(self, target)
-                rel.topology = self.topology
-                self.out_edges[rname][target.tosca_id] = rel
-                target.in_edges[rname][self.tosca_id] = rel
+                rel_instances = requirement.relationship.instantiate(self, target)
+                for rel in rel_instances:
+                    rel.topology = self.topology
+                    self.out_edges[rname][target.tosca_id] = rel
+                    target.in_edges[rname][self.tosca_id] = rel
+                    target.in_edges[rname][self.tosca_id] = rel
+                    rel.read()
 
     @property
     def deployed(self):

--- a/src/opera/instance/node.py
+++ b/src/opera/instance/node.py
@@ -127,12 +127,14 @@ class Node(Base):
     def get_attribute(self, params):
         host, attr, *rest = params
 
-        if host != "SELF":
-            raise DataError(
-                "Accessing non-local stuff is bad. Fix your service template."
-            )
         if host == "HOST":
             raise DataError("HOST is not yet supported in opera.")
+        if host != "SELF":
+            raise DataError(
+                "Attribute host should be set to 'SELF' which is the only "
+                "valid value. This is needed to indicate that the attribute "
+                "is referenced locally from something in the node itself."
+            )
 
         # TODO(@tadeboro): Add support for nested attribute values once we
         # have data type support.
@@ -178,12 +180,14 @@ class Node(Base):
     def map_attribute(self, params, value):
         host, attr, *rest = params
 
-        if host != "SELF":
-            raise DataError(
-                "Accessing non-local stuff is bad. Fix your service template."
-            )
         if host == "HOST":
             raise DataError("HOST is not yet supported in opera.")
+        if host != "SELF":
+            raise DataError(
+                "Attribute host should be set to 'SELF' which is the only "
+                "valid value. This is needed to indicate that the attribute "
+                "is referenced locally from something in the node itself."
+            )
 
         # TODO(@tadeboro): Add support for nested attribute values once we
         # have data type support.

--- a/src/opera/instance/relationship.py
+++ b/src/opera/instance/relationship.py
@@ -18,7 +18,7 @@ class Relationship(Base):
 
         if host not in ("SELF", "SOURCE", "TARGET"):
             raise DataError(
-                "Accessing non-local stuff is bad. Fix your service template."
+                "Attribute host should be set to 'SELF', 'SOURCE' or 'TARGET'."
             )
 
         if host == "SOURCE":
@@ -37,7 +37,7 @@ class Relationship(Base):
 
         if host not in ("SELF", "SOURCE", "TARGET"):
             raise DataError(
-                "Accessing non-local stuff is bad. Fix your service template."
+                "Property host should be set to 'SELF', 'SOURCE' or 'TARGET'."
             )
 
         if host == "SOURCE":
@@ -54,7 +54,7 @@ class Relationship(Base):
 
         if host not in ("SELF", "SOURCE", "TARGET"):
             raise DataError(
-                "Accessing non-local stuff is bad. Fix your service template."
+                "Attribute host should be set to 'SELF', 'SOURCE' or 'TARGET'."
             )
 
         if host == "SOURCE":
@@ -69,7 +69,7 @@ class Relationship(Base):
 
         if host not in ("SELF", "SOURCE", "TARGET"):
             raise DataError(
-                "Accessing non-local stuff is bad. Fix your service template."
+                "Artifact host should be set to 'SELF', 'SOURCE' or 'TARGET'."
             )
 
         if host == "SOURCE":

--- a/src/opera/parser/tosca/v_1_3/topology_template.py
+++ b/src/opera/parser/tosca/v_1_3/topology_template.py
@@ -31,7 +31,12 @@ class TopologyTemplate(Entity):
             outputs=self.collect_outputs(service_ast),
             nodes={
                 name: node_ast.get_template(name, service_ast)
-                for name, node_ast in self.node_templates.items()
+                for name, node_ast in self.get("node_templates", {}).items()
+            },
+            relationships={
+                name: rel_ast.get_template(name, service_ast)
+                for name, rel_ast in
+                self.get("relationship_templates", {}).items()
             },
         )
         topology.resolve_requirements()

--- a/src/opera/template/node.py
+++ b/src/opera/template/node.py
@@ -2,9 +2,6 @@ from opera.error import DataError
 from opera.instance.node import Node as Instance
 from pathlib import Path
 
-import tempfile, os
-from ..executor import utils
-
 
 class Node:
     def __init__(
@@ -131,7 +128,7 @@ class Node:
         return requirements[0].target.get_property(["SELF"] + rest)
 
     def get_attribute(self, params):
-        host, prop, *rest = params
+        host, attr, *rest = params
 
         if host != "SELF":
             raise DataError(

--- a/src/opera/template/node.py
+++ b/src/opera/template/node.py
@@ -86,12 +86,14 @@ class Node:
     def get_property(self, params):
         host, prop, *rest = params
 
-        if host != "SELF":
-            raise DataError(
-                "Accessing non-local stuff is bad. Fix your service template."
-            )
         if host == "HOST":
             raise DataError("HOST is not yet supported in opera.")
+        if host != "SELF":
+            raise DataError(
+                "Property host should be set to 'SELF' which is the only "
+                "valid value. This is needed to indicate that the property is "
+                "referenced locally from something in the node itself."
+            )
 
         # TODO(@tadeboro): Add support for nested property values.
         if prop in self.properties:
@@ -130,12 +132,14 @@ class Node:
     def get_attribute(self, params):
         host, attr, *rest = params
 
-        if host != "SELF":
-            raise DataError(
-                "Accessing non-local stuff is bad. Fix your service template."
-            )
         if host == "HOST":
             raise DataError("HOST is not yet supported in opera.")
+        if host != "SELF":
+            raise DataError(
+                "Attribute host should be set to 'SELF' which is the only "
+                "valid value. This is needed to indicate that the attribute "
+                "is referenced locally from something in the node itself."
+            )
         if len(self.instances) != 1:
             raise DataError("Cannot get an attribute from multiple instances")
 
@@ -147,12 +151,14 @@ class Node:
     def map_attribute(self, params, value):
         host, prop, *rest = params
 
-        if host != "SELF":
-            raise DataError(
-                "Accessing non-local stuff is bad. Fix your service template."
-            )
         if host == "HOST":
             raise DataError("HOST is not yet supported in opera.")
+        if host != "SELF":
+            raise DataError(
+                "Attribute host should be set to 'SELF' which is the only "
+                "valid value. This is needed to indicate that the attribute "
+                "is referenced locally from something in the node itself."
+            )
 
         if len(self.instances) != 1:
             raise DataError(
@@ -172,12 +178,14 @@ class Node:
         if len(rest) == 2:
             location, remove = rest
 
-        if host != "SELF":
-            raise DataError(
-                "Accessing non-local stuff is bad. Fix your service template."
-            )
         if host == "HOST":
             raise DataError("HOST is not yet supported in opera.")
+        if host != "SELF":
+            raise DataError(
+                "Artifact host should be set to 'SELF' which is the only "
+                "valid value. This is needed to indicate that the artifact "
+                "is referenced locally from something in the node itself."
+            )
 
         if location == "LOCAL_FILE":
             raise DataError("Location get_artifact property is "

--- a/src/opera/template/relationship.py
+++ b/src/opera/template/relationship.py
@@ -10,6 +10,12 @@ class Relationship:
         self.attributes = attributes
         self.interfaces = interfaces
 
+        # This will be set when the relationship is inserted into a topology
+        self.topology = None
+
+        # This will be set at instantiation time.
+        self.instances = None
+
     def is_a(self, typ):
         return typ in self.types
 

--- a/src/opera/template/relationship.py
+++ b/src/opera/template/relationship.py
@@ -21,7 +21,8 @@ class Relationship:
 
     def instantiate(self, source, target):
         relationship_id = "{}--{}".format(source.tosca_id, target.tosca_id)
-        return Instance(self, relationship_id, source, target)
+        self.instances = {relationship_id: Instance(self, relationship_id, source, target)}
+        return self.instances.values()
 
     def run_operation(self, host, interface, operation, instance, verbose,
                       workdir):
@@ -47,7 +48,45 @@ class Relationship:
         # have data type support.
         if prop not in self.properties:
             raise DataError("Template has no '{}' property".format(prop))
+
         return self.properties[prop].eval(self, prop)
+
+    def get_attribute(self, params):
+        host, attr, *rest = params
+
+        if host == "HOST":
+            raise DataError("HOST is not yet supported in opera.")
+        if host != "SELF":
+            raise DataError(
+                "Accessing non-local stuff is bad. Fix your service template."
+            )
+
+        if attr not in self.attributes:
+            raise DataError("Template has no '{}' attribute".format(attr))
+
+        try:
+            return self.attributes[attr].eval(self, attr)
+        except DataError:
+            pass
+
+        if len(self.instances) != 1:
+            raise DataError("Cannot get an attribute from multiple instances")
+
+        return next(iter(self.instances.values())).get_attribute(params)
 
     def get_input(self, params):
         return self.topology.get_input(params)
+
+    def map_attribute(self, params, value):
+        host, prop, *rest = params
+
+        if host not in ("SELF", "SOURCE", "TARGET"):
+            raise DataError(
+                "Attribute host should be set to 'SELF', 'SOURCE' or 'TARGET'."
+            )
+
+        if len(self.instances) != 1:
+            raise DataError(
+                "Mapping an attribute for multiple instances not supported")
+
+        next(iter(self.instances.values())).map_attribute(params, value)

--- a/src/opera/template/relationship.py
+++ b/src/opera/template/relationship.py
@@ -37,12 +37,14 @@ class Relationship:
     def get_property(self, params):
         host, prop, *rest = params
 
-        if host != "SELF":
-            raise DataError(
-                "Accessing non-local stuff is bad. Fix your service template."
-            )
         if host == "HOST":
             raise DataError("HOST is not yet supported in opera.")
+        if host != "SELF":
+            raise DataError(
+                "Property host should be set to 'SELF' which is the only "
+                "valid value. This is needed to indicate that the property is "
+                "referenced locally from something in the node itself."
+            )
 
         # TODO(@tadeboro): Add support for nested property values once we
         # have data type support.
@@ -58,7 +60,9 @@ class Relationship:
             raise DataError("HOST is not yet supported in opera.")
         if host != "SELF":
             raise DataError(
-                "Accessing non-local stuff is bad. Fix your service template."
+                "Attribute host should be set to 'SELF' which is the only "
+                "valid value. This is needed to indicate that the attribute "
+                "is referenced locally from something in the node itself."
             )
 
         if attr not in self.attributes:

--- a/src/opera/template/requirement.py
+++ b/src/opera/template/requirement.py
@@ -7,3 +7,4 @@ class Requirement:
 
     def resolve(self, topology):
         self.target = topology.get_node(self.target_name)
+        self.relationship.topology = topology

--- a/tests/integration/misc_tosca_types/modules/relationship_types/test/playbooks/test.yaml
+++ b/tests/integration/misc_tosca_types/modules/relationship_types/test/playbooks/test.yaml
@@ -10,4 +10,9 @@
     - name: Print whatever lies in relationship_property
       debug:
         msg: "{{ relationship_property }}"
+
+    - name: Set relationship attribute
+      set_stats:
+        data:
+          relationship_attribute: "This is a relationship attribute."
 ...

--- a/tests/integration/misc_tosca_types/modules/relationship_types/test/test.yaml
+++ b/tests/integration/misc_tosca_types/modules/relationship_types/test/test.yaml
@@ -4,6 +4,9 @@ tosca_definitions_version: tosca_simple_yaml_1_3
 relationship_types:
   daily_test.relationships.test:
     derived_from: tosca.relationships.HostedOn
+    attributes:
+      relationship_attribute:
+        type: string
     properties:
       relationship_property:
         type: string

--- a/tests/integration/misc_tosca_types/service-template.yaml
+++ b/tests/integration/misc_tosca_types/service-template.yaml
@@ -92,18 +92,21 @@ topology_template:
           properties:
             capability_property: capability_property_value
       requirements:
-        - host1: my-workstation1
-        - host2: my-workstation2
+        - host:
+            node: my-workstation2
+            relationship: test_rel
       artifacts:
         artifact:
           type: daily_test.artifacts.test
           file: modules/node_types/test/file.test
 
   relationship_templates:
-    test:
+    test_rel:
       type: daily_test.relationships.test
+      attributes:
+        relationship_attribute: rel_attr_test123
       properties:
-        relationship_property: test123
+        relationship_property: rel_prop_test123
 
     interfaces:
       type: daily_test.relationships.interfaces
@@ -121,10 +124,16 @@ topology_template:
         targets: [ hello, setter, workstation_group ]
 
   outputs:
-    output_prop:
+    node_output_prop:
       description: Example of property output
       value: { get_property: [ setter, my_property ] }
-    output_attr:
+    node_output_attr:
       description: Example of attribute output
       value: { get_attribute: [ setter, my_attribute ] }
+    relationship_output_prop:
+      description: Example of attribute output
+      value: { get_property: [ test_rel, relationship_property ] }
+    relationship_output_attr:
+      description: Example of attribute output
+      value: { get_attribute: [ test_rel, relationship_attribute ] }
 ...

--- a/tests/unit/opera/instance/test_attribute_mapping.py
+++ b/tests/unit/opera/instance/test_attribute_mapping.py
@@ -62,7 +62,8 @@ class TestAttributeMapping:
                               "other"])
     def test_map_attribute_node_bad_host(self, service_template, host):
         node = service_template.find_node("my_node")
-        with pytest.raises(DataError, match="Accessing non-local stuff"):
+        with pytest.raises(DataError, match="Attribute host should be set to "
+                                            "'SELF'"):
           node.map_attribute([host, "colour"], "black")
 
     def test_map_attribute_node_bad_attribute(self, service_template):
@@ -110,7 +111,8 @@ class TestAttributeMapping:
       relationship_instance = next(
         iter(node_source_instance.out_edges["my_target"].values()))
 
-      with pytest.raises(DataError, match="Accessing non-local stuff"):
+      with pytest.raises(DataError, match="Attribute host should be set to "
+                                          "'SELF'"):
         relationship_instance.map_attribute([host, "colour"], "ochre")
 
     @pytest.mark.parametrize("host, pattern", [


### PR DESCRIPTION
This PR applies changes that correspond to issues #117 and #119.

The changes from the first commit fully resolve the discovered issue that
an operation error is raised when using TOSCA get_input functions
inside the TOSCA relationship types. This can be problematic every time
when user would want to get initial inputs to a relationship.

The modifications in the second commit are based the example where we
were trying to use TOSCA outputs in order to get attributes, properties
or inputs from TOSCA relationship templates. Since this feature is
important and because it is possible to get node template's outputs for
a while now within opera, we wanted to add this for relationships too.
Here we apply some code changes to tell opera that TOSCA outputs can
come from node or relationship templates. At the end we realized the
similar behaviour as for the node templates. To be sure that we can
really get values from relationships, we composed an example which
resides in /examples/relationship_outputs. And of course, we also
applied this new functionality to our integration tests.

_________________________
This closes #117, closes #119.