### PR TITLE
Mark opera init as deprecated and enable compressed CSAR deployment with opera deploy

### DIFF
--- a/src/opera/commands/init.py
+++ b/src/opera/commands/init.py
@@ -42,6 +42,9 @@ def add_parser(subparsers):
 
 
 def _parser_callback(args):
+    print("Warning: 'opera init' command is deprecated and will probably be "
+          "removed within one of the next releases. Please use 'opera deploy' "
+          "to initialize and deploy service templates or compressed CSARs.")
     if args.instance_path and not path.isdir(args.instance_path):
         raise argparse.ArgumentTypeError("Directory {} is not a valid path!"
                                          .format(args.instance_path))

--- a/tests/integration/cli_commands/runme.sh
+++ b/tests/integration/cli_commands/runme.sh
@@ -22,6 +22,7 @@ test "$(echo "$info_out" | jq -r .status)" = "null"
 
 # test opera commands on TOSCA service template
 # init service template without inputs
+# warning: opera init is deprecated and could be removed in the future
 $opera_executable init service.yaml
 
 # test opera info status after init
@@ -42,7 +43,8 @@ $opera_executable deploy --clean-state --force
 info_out="$($opera_executable info --format json)"
 test "$(echo "$info_out" | jq -r .status)" = "deployed"
 
-# init service template again (with clean option and with inputs)
+# init service template again (with clean option and with inputs
+# warning: opera init is deprecated and could be removed in the future
 $opera_executable init --clean service.yaml
 
 # test opera info status after init
@@ -82,13 +84,13 @@ test "$(echo "$info_out" | jq -r .status)" = "undeployed"
 # run opera info with YAML format
 $opera_executable info --format yaml
 
-
 # test opera commands on CSAR
 # prepare new opera storage folder
 mkdir -p ./csar-test-dir
 
 # initialize the CSAR (from the prepared compressed CSAR file)
 # also provide inputs and relocate opera storage to some other folder
+# warning: opera init is deprecated and could be removed in the future
 $opera_executable init -i inputs.yaml --instance-path ./csar-test-dir --clean test.csar
 
 # test opera info status after init
@@ -104,6 +106,21 @@ test "$(echo "$info_out" | jq -r .status)" = "deployed"
 
 # deploy the initialized CSAR again (with clean state and without yes/no prompts)
 $opera_executable deploy -p ./csar-test-dir -c -f
+
+# test opera info status after deploy
+info_out="$($opera_executable info -p ./csar-test-dir -f json)"
+test "$(echo "$info_out" | jq -r .status)" = "deployed"
+
+# take a look at opera outputs
+$opera_executable outputs -p ./csar-test-dir
+
+# test opera info status after outputs
+info_out="$($opera_executable info -p ./csar-test-dir -f json)"
+test "$(echo "$info_out" | jq -r .status)" = "deployed"
+
+# deploy the compressed CSAR agin, now directly without deprecated opera init
+# use clean state and disable yes/no prompts
+$opera_executable deploy -i inputs.yaml --instance-path ./csar-test-dir --clean --force test.csar
 
 # test opera info status after deploy
 info_out="$($opera_executable info -p ./csar-test-dir -f json)"

--- a/tests/integration/misc_tosca_types/runme.sh
+++ b/tests/integration/misc_tosca_types/runme.sh
@@ -19,6 +19,7 @@ $opera_executable undeploy
 $opera_executable info
 
 # integration test with compressed CSAR
+# warning: opera init is deprecated and could be removed in the future
 rm -rf .opera
 mkdir -p csar-test
 zip -r test.csar service-template.yaml modules TOSCA-Metadata
@@ -26,10 +27,18 @@ mv test.csar csar-test
 mv inputs.yaml csar-test
 cd csar-test
 $opera_executable info -f yaml
+# deploy compressed CSAR (with opera init)
 $opera_executable init -i inputs.yaml test.csar
 $opera_executable info -f json
 $opera_executable deploy
 $opera_executable info -f yaml
+$opera_executable outputs
+$opera_executable info -f json
+$opera_executable undeploy
+$opera_executable info
+# deploy compressed CSAR again (without opera init)
+$opera_executable deploy -i inputs.yaml -c -f test.csar
+$opera_executable info -f json
 $opera_executable outputs
 $opera_executable info -f json
 $opera_executable undeploy


### PR DESCRIPTION
These changes correspond to the debate within the #107 issue. There we
have agreed that opera init command is unneeded at the moment as it
does not do anything different from opera deploy (apart from just
skipping the last deployment step). We can achieve the same behavior
with opera deploy by adding the compressed CSAR initialization logic.
And that's exactly what we did. Users are now able to deploy TOSCA
service templates, uncompressed CSARs or compressed CSARs with opera
deploy. We thought about the possibility that some users would still
initialize the service template/CSAR first and the deploy, so we kept
the option to run just opera deploy after the initialization.

As opera init command currently has no benefits, we are also applying the
changes that will warn the users that opera init CLI command is deprecated 
and that he can just use opera deploy instead.
