### PR TITLE
Equip opera CLI with CSAR unpackaging command

### DIFF
--- a/src/opera/commands/__init__.py
+++ b/src/opera/commands/__init__.py
@@ -1,8 +1,9 @@
 from opera.commands import (
-    validate,
-    init,
-    info,
     deploy,
+    info,
+    init,
+    outputs,
     undeploy,
-    outputs
+    unpackage,
+    validate
 )

--- a/src/opera/commands/deploy.py
+++ b/src/opera/commands/deploy.py
@@ -191,7 +191,7 @@ def deploy_compressed_csar(csar_name: str, inputs: typing.Optional[dict],
     csars_dir.mkdir(exist_ok=True)
 
     # validate csar
-    csar = CloudServiceArchive(csar_name, csars_dir)
+    csar = CloudServiceArchive(csar_name)
     tosca_service_template = csar.validate_csar()
 
     # unzip csar, save the path to storage and set workdir

--- a/src/opera/commands/init.py
+++ b/src/opera/commands/init.py
@@ -95,7 +95,7 @@ def init_compressed_csar(csar_name: str, inputs: typing.Optional[dict],
     csars_dir.mkdir(exist_ok=True)
 
     # validate csar
-    csar = CloudServiceArchive(csar_name, csars_dir)
+    csar = CloudServiceArchive(csar_name)
     tosca_service_template = csar.validate_csar()
 
     # unzip csar and save the path to storage

--- a/src/opera/commands/unpackage.py
+++ b/src/opera/commands/unpackage.py
@@ -1,0 +1,68 @@
+import argparse
+
+from pathlib import Path
+
+from opera.error import DataError, ParseError
+from opera.parser.tosca.csar import CloudServiceArchive
+from opera.utils import determine_archive_format, generate_random_pathname
+
+
+def add_parser(subparsers):
+    parser = subparsers.add_parser(
+        "unpackage",
+        help="Unpackage TOSCA CSAR to a specified location"
+    )
+    parser.add_argument(
+        "--destination", "-d",
+        help="Path to the location where the CSAR file will be extracted to, "
+             "the path will be generated in the current working directory if "
+             "it isn't specified",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action='store_true',
+        help="Turns on verbose mode",
+    )
+    parser.add_argument("csar", help="Path to the compressed TOSCA CSAR")
+    parser.set_defaults(func=_parser_callback)
+
+
+def _parser_callback(args):
+    csar_path = Path(args.csar)
+    if not csar_path.is_file():
+        raise argparse.ArgumentTypeError("CSAR file {} is not a valid path!"
+                                         .format(args.csar))
+
+    # if the output is set use it, if not create a random file name with UUID
+    if args.destination:
+        extracted_folder = Path(args.destination)
+    else:
+        # generate a unique extracted CSAR folder name
+        extracted_folder = Path(generate_random_pathname("opera-unpackage-"))
+
+    try:
+        abs_csar_path = str(csar_path.resolve())
+        abs_dest_path = str(extracted_folder.resolve())
+
+        archive_format = determine_archive_format(abs_csar_path)
+        unpackage(abs_csar_path, abs_dest_path, archive_format)
+        print("The CSAR was unpackaged to '{}'.".format(abs_dest_path))
+    except ParseError as e:
+        print("{}: {}".format(e.loc, e))
+        return 1
+    except DataError as e:
+        print(str(e))
+        return 1
+
+    return 0
+
+
+def unpackage(csar_input: str, output_dir: str, csar_format: str):
+    """
+    :raises ParseError:
+    :raises DataError:
+    """
+    csar = CloudServiceArchive(csar_input)
+    # validate CSAR before unpacking it
+    csar.validate_csar()
+    # unpack the CSAR to the specified location
+    csar.unpackage_csar(output_dir, csar_format)

--- a/src/opera/commands/validate.py
+++ b/src/opera/commands/validate.py
@@ -61,7 +61,7 @@ def validate_compressed_csar(csar_name: str, inputs: typing.Optional[dict]):
 
     with TemporaryDirectory() as csar_validation_dir:
         # validate csar structure
-        csar = CloudServiceArchive(csar_name, csar_validation_dir)
+        csar = CloudServiceArchive(csar_name)
         tosca_service_template = csar.validate_csar()
 
         # unzip csar to temporary folder

--- a/src/opera/parser/tosca/csar.py
+++ b/src/opera/parser/tosca/csar.py
@@ -1,21 +1,28 @@
+import shutil
+import yaml
+
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile
 
-import yaml
 from opera.error import ParseError
 
 
 class CloudServiceArchive:
-    def __init__(self, csar_name, csar_folder_path):
+    def __init__(self, csar_name):
         self._csar_name = csar_name
-        self._csar_folder_path = csar_folder_path
         self._tosca_meta = None
         self._root_yaml_template = None
         self._metadata = None
 
+    def unpackage_csar(self, output_dir, csar_format="zip"):
+        # validate CSAR before unpacking it
+        self.validate_csar()
+        # unpack the CSAR to the specified location
+        shutil.unpack_archive(self._csar_name, output_dir, csar_format)
+
     def validate_csar(self):
-        with TemporaryDirectory(dir=self._csar_folder_path) as tempdir:
+        with TemporaryDirectory() as tempdir:
             ZipFile(self._csar_name, 'r').extractall(tempdir)
 
             try:

--- a/src/opera/parser/tosca/csar.py
+++ b/src/opera/parser/tosca/csar.py
@@ -16,8 +16,6 @@ class CloudServiceArchive:
         self._metadata = None
 
     def unpackage_csar(self, output_dir, csar_format="zip"):
-        # validate CSAR before unpacking it
-        self.validate_csar()
         # unpack the CSAR to the specified location
         shutil.unpack_archive(self._csar_name, output_dir, csar_format)
 

--- a/src/opera/utils.py
+++ b/src/opera/utils.py
@@ -1,3 +1,7 @@
+from zipfile import is_zipfile
+from tarfile import is_tarfile
+from uuid import uuid4
+from os import path
 
 
 def prompt_yes_no_question(yes_responses=("y", "yes"),
@@ -21,10 +25,29 @@ def prompt_yes_no_question(yes_responses=("y", "yes"),
         elif check in no_responses:
             return False
         else:
-            print('Invalid input. Please try again.')
+            print("Invalid input. Please try again.")
             return prompt_yes_no_question(yes_responses, no_responses,
                                           case_sensitive, default_yes_response)
     except Exception as e:
         print("Exception occurred: {}. Please enter valid inputs.".format(e))
         return prompt_yes_no_question(yes_responses, no_responses,
                                       case_sensitive, default_yes_response)
+
+
+def determine_archive_format(filepath):
+    if is_tarfile(filepath):
+        return "tar"
+    elif is_zipfile(filepath):
+        return "zip"
+    else:
+        raise Exception("Unaccepted archive file: '{}'. The compression "
+                        "format should be zip or tar.".format(filepath))
+
+
+def generate_random_pathname(prefix=""):
+    # use uuid4 to create a unique random pathname and select last 6 characters
+    pathname = prefix + str(uuid4().hex)[-6:]
+    if path.exists(pathname):
+        return generate_random_pathname(prefix)
+    else:
+        return pathname

--- a/tests/integration/cli_commands/runme.sh
+++ b/tests/integration/cli_commands/runme.sh
@@ -84,6 +84,27 @@ test "$(echo "$info_out" | jq -r .status)" = "undeployed"
 # run opera info with YAML format
 $opera_executable info --format yaml
 
+# unpack the created CSAR to the destination folder with opera unpackage
+$opera_executable unpackage -d unpacked-csar test.csar
+
+# test opera info status after unpackage
+info_out="$($opera_executable info --format json)"
+test "$(echo "$info_out" | jq -r .status)" = "undeployed"
+
+# move to the root of the extracted CSAR and
+# deploy the extracted service template with inputs
+cd unpacked-csar
+$opera_executable deploy --inputs ../inputs.yaml service.yaml
+
+# test opera info status after deploy
+info_out="$($opera_executable info --format json)"
+test "$(echo "$info_out" | jq -r .status)" = "deployed"
+
+# move one level up and remove the extracted folder
+cd ..
+rm -rf unpacked-csar
+
+
 # test opera commands on CSAR
 # prepare new opera storage folder
 mkdir -p ./csar-test-dir

--- a/tests/integration/misc_tosca_types/runme.sh
+++ b/tests/integration/misc_tosca_types/runme.sh
@@ -24,7 +24,7 @@ rm -rf .opera
 mkdir -p csar-test
 zip -r test.csar service-template.yaml modules TOSCA-Metadata
 mv test.csar csar-test
-mv inputs.yaml csar-test
+cp inputs.yaml csar-test
 cd csar-test
 $opera_executable info -f yaml
 # deploy compressed CSAR (with opera init)
@@ -42,6 +42,13 @@ $opera_executable info -f json
 $opera_executable outputs
 $opera_executable info -f json
 $opera_executable undeploy
+$opera_executable info
+# use opera unpackage and unpack the CSAR and deploy the extracted TOSCA files
+$opera_executable unpackage -d unpacked-csar test.csar
+$opera_executable info
+cp inputs.yaml unpacked-csar
+cd unpacked-csar
+$opera_executable deploy -i inputs.yaml service-template.yaml
 $opera_executable info
 # number of created .opera folders should be 1
 opera_count=$(ls -aR . | grep -c "^\.opera$")


### PR DESCRIPTION
The issue #124 presented the importance of having both, packaging and
unpackaging commands supported within the opera TOSCA orchestrator.
So be it. In this commit we are boosting up opera's CLI commands
by introducing the new opera unpackage command, which will serve for
unpacking (i.e. validating and extracting) the compressed TOSCA CSAR
files. The opera unpackage command receives a compressed CSAR as a
positional argument. It then validates and extracts the CSAR to a
given location. The available command switches are:

  1. --destination/-d is the folder location where the CSAR will be
     extracted to. If the specified path does not exists, it will be
     created during the unpackaging process. The flag can be omitted
     and this means that the output dir will be named using UUID.

  2. --format/-f is the option that specifies the compressed file
     format that will be used to extract the CSAR. Currently, there
     are two choices here: 'zip' or 'tar', where 'zip' is the
     default compression method.
____
Examples of usage for `opera unpackage`:

```console
# unpack the CSAR without specifying the location
(.venv) anzoman@ubuntu:~/Desktop/xopera-opera$ opera unpackage test.zip
The CSAR was unpackaged to 'opera-unpackage-65a14dbd0e3e43c5aa9045f6dcba93b5'.

# unpackage the CSAR, specify (unexisting) destination folder and format
(.venv) anzoman@ubuntu:~/Desktop/xopera-opera$ opera unpackage -d extracted_csar -f zip test.zip
The CSAR was unpackaged to 'extracted_csar'.

# opera unpackage fails before the CSRA extraction due to invalid CSAR
(.venv) anzoman@ubuntu:~/Desktop/xopera-opera$ opera unpackage csar.zip 
<opera.parser.tosca.csar.CloudServiceArchive object at 0x7f952e6d6a90>: Invalid CSAR structure: The file "service-template.yaml" defined within "Entry-Definitions" in "TOSCA-Metadata/TOSCA.meta" does not exist.
```
____
Related to #42 
Closes #124 