### PR TITLE
Mention that orchestration inputs can be also passed as JSON

### DIFF
--- a/src/opera/commands/deploy.py
+++ b/src/opera/commands/deploy.py
@@ -25,7 +25,7 @@ def add_parser(subparsers):
     )
     parser.add_argument(
         "--inputs", "-i", type=argparse.FileType("r"),
-        help="Optional: YAML file with inputs to "
+        help="YAML or JSON file with inputs to "
              "override the inputs supplied in init",
     )
     parser.add_argument(

--- a/src/opera/commands/init.py
+++ b/src/opera/commands/init.py
@@ -24,7 +24,7 @@ def add_parser(subparsers):
     )
     parser.add_argument(
         "--inputs", "-i", type=argparse.FileType("r"),
-        help="YAML file with inputs",
+        help="YAML or JSON file with inputs",
     )
     parser.add_argument(
         "--clean", "-c", action='store_true',
@@ -50,7 +50,6 @@ def _parser_callback(args):
                                          .format(args.instance_path))
 
     storage = Storage.create(args.instance_path)
-
     try:
         inputs = yaml.safe_load(args.inputs) if args.inputs else {}
     except Exception as e:

--- a/src/opera/commands/validate.py
+++ b/src/opera/commands/validate.py
@@ -18,7 +18,7 @@ def add_parser(subparsers):
     )
     parser.add_argument(
         "--inputs", "-i", type=argparse.FileType("r"),
-        help="YAML file with inputs",
+        help="YAML or JSON file with inputs",
     )
     parser.add_argument(
         "--verbose", "-v", action='store_true',

--- a/tests/integration/cli_commands/inputs.json
+++ b/tests/integration/cli_commands/inputs.json
@@ -1,0 +1,4 @@
+{
+  "test_attribute_input": 10,
+  "test_property_input": true
+}

--- a/tests/integration/cli_commands/runme.sh
+++ b/tests/integration/cli_commands/runme.sh
@@ -12,9 +12,17 @@ zip -r test.csar service.yaml playbooks TOSCA-Metadata
 info_out="$($opera_executable info --format json)"
 test "$(echo "$info_out" | jq -r .status)" = "null"
 
-# validate service template and CSAR
+# validate service template and CSAR (with YAML inputs)
 $opera_executable validate --inputs inputs.yaml service.yaml
 $opera_executable validate --inputs inputs.yaml test.csar
+
+# test opera info status after validate
+info_out="$($opera_executable info --format json)"
+test "$(echo "$info_out" | jq -r .status)" = "null"
+
+# validate service template and CSAR (with JSON inputs)
+$opera_executable validate --inputs inputs.json service.yaml
+$opera_executable validate --inputs inputs.json test.csar
 
 # test opera info status after validate
 info_out="$($opera_executable info --format json)"
@@ -38,6 +46,22 @@ test "$(echo "$info_out" | jq -r .status)" = "deployed"
 
 # deploy service template again (with clean state and without yes/no prompts)
 $opera_executable deploy --clean-state --force
+
+# test opera info status after deploy
+info_out="$($opera_executable info --format json)"
+test "$(echo "$info_out" | jq -r .status)" = "deployed"
+
+# deploy service template again (with clean state and without yes/no prompts)
+# use YAML inputs
+$opera_executable deploy --inputs inputs.yaml -c -f service.yaml
+
+# test opera info status after deploy
+info_out="$($opera_executable info --format json)"
+test "$(echo "$info_out" | jq -r .status)" = "deployed"
+
+# deploy service template again (with clean state and without yes/no prompts)
+# use JSON inputs this time
+$opera_executable deploy --inputs inputs.json -c -f service.yaml
 
 # test opera info status after deploy
 info_out="$($opera_executable info --format json)"
@@ -118,9 +142,17 @@ $opera_executable outputs -p ./csar-test-dir
 info_out="$($opera_executable info -p ./csar-test-dir -f json)"
 test "$(echo "$info_out" | jq -r .status)" = "deployed"
 
-# deploy the compressed CSAR agin, now directly without deprecated opera init
+# deploy the compressed CSAR again, now directly without deprecated opera init
 # use clean state and disable yes/no prompts
 $opera_executable deploy -i inputs.yaml --instance-path ./csar-test-dir --clean --force test.csar
+
+# test opera info status after deploy
+info_out="$($opera_executable info -p ./csar-test-dir -f json)"
+test "$(echo "$info_out" | jq -r .status)" = "deployed"
+
+# deploy the compressed CSAR again, now directly without deprecated opera init
+# use clean state and disable yes/no prompts, use JSON inputs
+$opera_executable deploy -i inputs.json -p ./csar-test-dir -c -f test.csar
 
 # test opera info status after deploy
 info_out="$($opera_executable info -p ./csar-test-dir -f json)"


### PR DESCRIPTION
Inputs can be very important for the orchestration process as they
often include various secrets and variables that are used to
authenticate and to deploy applications. Up until now inputs were
passed to the orchestrator as a YAML file with key-value pairs.
To make our TOSCA orchestrator more flexible we can extend inputs
format (this was originally explained in the issue #122). So, with
these changes we are adding the possibility to supply inputs also
in JSON format. This was not very hard because opera already stores
inputs as a JSON file in its storage folder (.opera by default) and
therefore we only had to modify the things for certain CLI commands.
This is the part where --inputs-format CLI option has been brought to
life. It can be used to specify the desired YAML or JSON inputs format
(YAML is used by default) for validate, init or deploy CLI command.

The new option `--inputs-format` can be used like this:

```console
# validate TOSCA service template with YAML inputs
# --inputs-format is not used and defaults to yaml
(.venv) anzoman@ubuntu:~/Desktop/xopera-opera/templates/misc-tosca-types$ opera validate -i inputs.yaml service-template.yaml
Validating service template ...
Done.

# validate TOSCA service template with JSON inputs
(.venv) anzoman@ubuntu:~/Desktop/xopera-opera/templates/misc-tosca-types$ opera validate -i inputs.json --inputs-format json service-template.yaml
Validating service template ...
Done.

# initialize TOSCA service template with YAML inputs
(.venv) anzoman@ubuntu:~/Desktop/xopera-opera/templates/misc-tosca-types$ opera init -i inputs.yaml --inputs-format yaml service-template.yaml
Service template was initialized

# deploy the initialize TOSCA service template and override YAML inputs with JSON inputs
(.venv) anzoman@ubuntu:~/Desktop/xopera-opera/templates/misc-tosca-types$ opera deploy -i inputs.json --inputs-format json
[Worker_0]   Deploying my-workstation1_0
...
```
___________
Closes #122 