### PR TITLE
corrected operation name to match interface

### DIFF
--- a/tests/integration/misc-tosca-types/modules/relationship_types/test/test.yaml
+++ b/tests/integration/misc-tosca-types/modules/relationship_types/test/test.yaml
@@ -11,7 +11,7 @@ relationship_types:
     interfaces:
       Configure:
         operations:
-          configure_target:
+          pre_configure_target:
             inputs:
               relationship_property:
                 default: { get_property: relationship_property }


### PR DESCRIPTION
There is no operation called `configure_target` on the `tosca.interfaces.relationship.Configure` interface type. It should be `pre_configure_target` or `post_configure_target`.