### PR TITLE
Make TOSCA properties required by default

### DIFF
--- a/examples/intrinsic_functions/service.yaml
+++ b/examples/intrinsic_functions/service.yaml
@@ -35,6 +35,7 @@ node_types:
         default: { concat: [ 'Property: ', get_attribute: [ SELF, attribute3_2 ] ] }
       property3_3:
         type: string
+        required: false
 
 topology_template:
   inputs:

--- a/src/opera/parser/tosca/v_1_3/collector_mixin.py
+++ b/src/opera/parser/tosca/v_1_3/collector_mixin.py
@@ -19,6 +19,22 @@ class CollectorMixin:
                 ", ".join(undeclared_props),
             ), self.loc)
 
+        for key, prop_definition in definitions.items():
+            prop_required = prop_definition.get("required", None)
+            prop_has_default = prop_definition.get("default", None)
+            prop_assignment = assignments.get(key, None)
+            if prop_required:
+                prop_required = prop_required.data
+            else:
+                prop_required = True
+
+            if prop_required and not prop_has_default and not prop_assignment:
+                self.abort("Missing a required property: {}. If the property "
+                           "is optional please specify this in the definition "
+                           "with 'required: false' or supply its default "
+                           "value using 'default: <value>'.".format(key),
+                           self.loc)
+
         return {
             name: (assignments.get(name) or definition).get_value(
                 definition.get_value_type(service_ast),

--- a/tests/integration/misc_tosca_types/modules/node_types/noimpl/noimpl.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/noimpl/noimpl.yaml
@@ -7,6 +7,8 @@ node_types:
     properties:
       test_integer:
         type: integer
+        required: true
       test_string:
         type: string
+        required: false
 ...

--- a/tests/integration/misc_tosca_types/modules/node_types/test/test.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/test/test.yaml
@@ -20,6 +20,7 @@ node_types:
     properties:
       test:
         type: daily_test.datatypes.test
+        required: false
     interfaces:
       Standard:
         operations:

--- a/tests/integration/misc_tosca_types/service-template.yaml
+++ b/tests/integration/misc_tosca_types/service-template.yaml
@@ -72,6 +72,8 @@ topology_template:
 
     noimpl:
       type: daily_test.nodes.noimpl
+      properties:
+        test_integer: 42
       requirements:
         - host: my-workstation1
 


### PR DESCRIPTION
Here we are addressing the issue that has been originally spotted in
#131. There is an additional requirement for property (and parameter
definitions) that has to be satisfied in order to stick with the
TOSCA Simple Profile in YAML version 1.3. Every defined property
should be considered required by default unless its required keyname is
explicitly set to false. With these changes we make sure that the users
will be warned if some required property is missing its value and in
these cases the deployment process will fail. According to that we also
needed to update some of TOSCA templates among the examples and
integration tests as there were required properties that were not used.

Fixes #131.