### PR TITLE
Introduce opera tab completion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml >= 3.10  # MIT
 ansible >= 2.8  # GPLv3
+shtab >= 1.3.3  # Apache 2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ setup_requires =
 install_requires =
   ansible >= 2.8
   pyyaml >= 3.10
+  shtab >= 1.3.3
 
 [options.packages.find]
 where = src

--- a/src/opera/cli.py
+++ b/src/opera/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import inspect
 import sys
+import shtab
 
 from opera import commands
 
@@ -37,5 +38,10 @@ def create_parser():
 
 def main():
     parser = create_parser()
+    # use shtab magic
+    # add global optional argument for generating shell completion script
+    shtab.add_argument_to(parser, ["-s", "--shell-completion"],
+                          help="Generate tab completion script for your shell"
+                          )
     args = parser.parse_args()
     return args.func(args)

--- a/src/opera/commands/deploy.py
+++ b/src/opera/commands/deploy.py
@@ -1,6 +1,7 @@
 import argparse
 import typing
 import yaml
+import shtab
 
 from os import path
 from pathlib import Path, PurePath
@@ -27,7 +28,7 @@ def add_parser(subparsers):
         "--inputs", "-i", type=argparse.FileType("r"),
         help="YAML or JSON file with inputs to "
              "override the inputs supplied in init",
-    )
+    ).complete = shtab.FILE
     parser.add_argument(
         "--workers", "-w",
         help="Maximum number of concurrent deployment "
@@ -52,10 +53,10 @@ def add_parser(subparsers):
         "--verbose", "-v", action='store_true',
         help="Turns on verbose mode",
     )
-    parser.add_argument("template",
-                        type=argparse.FileType("r"), nargs='?',
-                        help="TOSCA YAML service template file",
-                        )
+    parser.add_argument(
+        "template", type=argparse.FileType("r"), nargs='?',
+        help="TOSCA YAML service template file",
+    ).complete = shtab.FILE
     parser.set_defaults(func=_parser_callback)
 
 

--- a/src/opera/commands/info.py
+++ b/src/opera/commands/info.py
@@ -1,9 +1,10 @@
 import argparse
 import json
+import yaml
+import shtab
+
 from os import path
 from pathlib import Path, PurePath
-
-import yaml
 
 from opera.error import DataError, ParseError
 from opera.parser import tosca
@@ -18,7 +19,7 @@ def add_parser(subparsers):
     parser.add_argument(
         "--instance-path", "-p",
         help=".opera storage folder location"
-    )
+    ).complete = shtab.DIR
     parser.add_argument(
         "--format", "-f", choices=("yaml", "json"), type=str,
         default="yaml", help="Output format",

--- a/src/opera/commands/init.py
+++ b/src/opera/commands/init.py
@@ -1,6 +1,7 @@
 import argparse
 import typing
 import yaml
+import shtab
 
 from os import path
 from pathlib import Path, PurePath
@@ -21,11 +22,11 @@ def add_parser(subparsers):
     parser.add_argument(
         "--instance-path", "-p",
         help=".opera storage folder location"
-    )
+    ).complete = shtab.DIR
     parser.add_argument(
         "--inputs", "-i", type=argparse.FileType("r"),
         help="YAML or JSON file with inputs",
-    )
+    ).complete = shtab.FILE
     parser.add_argument(
         "--clean", "-c", action='store_true',
         help="Clean storage by removing previously "
@@ -35,9 +36,10 @@ def add_parser(subparsers):
         "--verbose", "-v", action='store_true',
         help="Turns on verbose mode",
     )
-    parser.add_argument("csar",
-                        type=argparse.FileType("r"),
-                        help="Cloud service archive or service template file")
+    parser.add_argument(
+        "csar", type=argparse.FileType("r"),
+        help="Cloud service archive or service template file"
+    ).complete = shtab.FILE
     parser.set_defaults(func=_parser_callback)
 
 

--- a/src/opera/commands/outputs.py
+++ b/src/opera/commands/outputs.py
@@ -1,4 +1,5 @@
 import argparse
+import shtab
 
 from os import path
 from pathlib import Path, PurePath
@@ -17,7 +18,7 @@ def add_parser(subparsers):
     parser.add_argument(
         "--instance-path", "-p",
         help=".opera storage folder location"
-    )
+    ).complete = shtab.DIR
     parser.add_argument(
         "--format", "-f", choices=("yaml", "json"), type=str,
         default="yaml", help="Output format",

--- a/src/opera/commands/package.py
+++ b/src/opera/commands/package.py
@@ -25,6 +25,10 @@ def add_parser(subparsers):
         "--format", "-f", choices=("zip", "tar"),
         default="zip", help="CSAR compressed file format",
     )
+    parser.add_argument(
+        "--verbose", "-v", action='store_true',
+        help="Turns on verbose mode",
+    )
     parser.add_argument("service_template_folder",
                         help="Path to the root of the service template or "
                              "folder you want to create the TOSCA CSAR from")

--- a/src/opera/commands/package.py
+++ b/src/opera/commands/package.py
@@ -1,4 +1,5 @@
 import argparse
+import shtab
 
 from pathlib import Path
 
@@ -29,9 +30,11 @@ def add_parser(subparsers):
         "--verbose", "-v", action='store_true',
         help="Turns on verbose mode",
     )
-    parser.add_argument("service_template_folder",
-                        help="Path to the root of the service template or "
-                             "folder you want to create the TOSCA CSAR from")
+    parser.add_argument(
+        "service_template_folder",
+        help="Path to the root of the service template or "
+             "folder you want to create the TOSCA CSAR from"
+    ).complete = shtab.FILE
     parser.set_defaults(func=_parser_callback)
 
 

--- a/src/opera/commands/undeploy.py
+++ b/src/opera/commands/undeploy.py
@@ -1,4 +1,6 @@
 import argparse
+import shtab
+
 from pathlib import Path, PurePath
 from os import path
 
@@ -17,7 +19,7 @@ def add_parser(subparsers):
     parser.add_argument(
         "--instance-path", "-p",
         help=".opera storage folder location"
-    )
+    ).complete = shtab.DIR
     parser.add_argument(
         "--workers", "-w",
         help="Maximum number of concurrent undeployment "

--- a/src/opera/commands/unpackage.py
+++ b/src/opera/commands/unpackage.py
@@ -1,4 +1,5 @@
 import argparse
+import shtab
 
 from pathlib import Path
 
@@ -17,12 +18,14 @@ def add_parser(subparsers):
         help="Path to the location where the CSAR file will be extracted to, "
              "the path will be generated in the current working directory if "
              "it isn't specified",
-    )
+    ).complete = shtab.DIR
     parser.add_argument(
         "--verbose", "-v", action='store_true',
         help="Turns on verbose mode",
     )
-    parser.add_argument("csar", help="Path to the compressed TOSCA CSAR")
+    parser.add_argument(
+        "csar", help="Path to the compressed TOSCA CSAR"
+    ).complete = shtab.FILE
     parser.set_defaults(func=_parser_callback)
 
 

--- a/src/opera/commands/validate.py
+++ b/src/opera/commands/validate.py
@@ -1,6 +1,7 @@
 import argparse
 import typing
 import yaml
+import shtab
 
 from tempfile import TemporaryDirectory
 from pathlib import Path, PurePath
@@ -19,14 +20,15 @@ def add_parser(subparsers):
     parser.add_argument(
         "--inputs", "-i", type=argparse.FileType("r"),
         help="YAML or JSON file with inputs",
-    )
+    ).complete = shtab.FILE
     parser.add_argument(
         "--verbose", "-v", action='store_true',
         help="Turns on verbose mode",
     )
-    parser.add_argument("csar",
-                        type=argparse.FileType("r"),
-                        help="Cloud service archive or service template file")
+    parser.add_argument(
+        "csar", type=argparse.FileType("r"),
+        help="Cloud service archive or service template file"
+    ).complete = shtab.FILE
     parser.set_defaults(func=_parser_callback)
 
 


### PR DESCRIPTION
This PR does the following:

- refactor comment in setup.py 
- add a missing verbose flag to opera package CLI command 
- implement opera tab completion

Shell completion is the most important here.

It seems that [argcomplete](https://github.com/kislyuk/argcomplete) Python package might not be the
best solution for subparsers and also has other drawbacks.
We are able to use [shtab](https://github.com/iterative/shtab) in our code to generate a shell completion
script. And we don't even need a separate command to do that since
shtab supports defining a global optional argument that will print
out the completion script for the main parser. We used that and
defined `--shell-completion/-s` flag which receives a shell type to
generate completion for. Shtab currenty supports bash and zsh so those
are the options. So, after running `opera -s bash|zsh` the generated
tab completion script will be printed out. To activate it you must
source the contents which can be done with `eval "$(opera -s bash)"`
or you can save it to a file and then source it. The procedure will
be fully explained in the opera documentation.

Closes #56.