### PR TITLE
Stateless info

### DIFF
--- a/src/opera/commands/deploy.py
+++ b/src/opera/commands/deploy.py
@@ -70,7 +70,7 @@ def _parser_callback(args):
         return 1
 
     storage = Storage.create(args.instance_path)
-    status = info(storage)["status"]
+    status = info(None, storage)["status"]
     delete_existing_state = False
 
     if storage.exists("instances"):

--- a/src/opera/commands/undeploy.py
+++ b/src/opera/commands/undeploy.py
@@ -51,7 +51,7 @@ def _parser_callback(args):
         return 1
 
     storage = Storage.create(args.instance_path)
-    status = info(storage)["status"]
+    status = info(None, storage)["status"]
 
     if storage.exists("instances"):
         if args.resume and status == "interrupted":


### PR DESCRIPTION
A WIP because it depends on #153.

Info will now use CSAR metadata to fill out some `info` fields, which will make xopera-saas be able to autofill the service template name even before anything is deployed.