### PR TITLE
Specify README format in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ author_email = pypi@xlab.si
 license_file = LICENSE
 description = Lightweight TOSCA orchestrator
 long_description = file: README.md
+long_description_content_type = text/markdown
 keywords = orchestration
 classifiers =
     Development Status :: 2 - Pre-Alpha

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import setuptools
 
 
-# configures that the local component of the version is constructed without commit hash
+# constructs the local component of the version without the commit hash
 def local_scheme(version):
     return ""
 


### PR DESCRIPTION
In order to successfully render our README while publishing on PyPI we
need to specify the format of the README as 'text/markdown'. Without
this publishing on PyPI with twine fails as the format defaults to
rst (reStructuredText). And since we use more friendly md (markdown) for
our README we added long_description_content_type metadata to setup.cfg.