### PR TITLE
Fix SaaS CLI docs to use RADON auth

### DIFF
--- a/docs/saas.rst
+++ b/docs/saas.rst
@@ -17,15 +17,30 @@ Using the xOpera SaaS API through ``curl``::
 
     csar_base64="$(base64 --wrap 0 test.csar)"
     api="https://xopera-radon.xlab.si/api"
+    auth_base_url="https://openid-radon.xlab.si"
     secret_base64="$(echo 'hello!' | base64 -)"
 
     your_username=YOUR_USERNAME
     your_password=YOUR_PASSWORD
 
-    # login process (would be automated by browser)
     alias cookiecurl="curl -sSL --cookie-jar cookiejar.txt --cookie cookiejar.txt"
-    response="$(cookiecurl $api/credential)"
-    redirect_url="$(echo $response | xmllint --html --xpath "string(//form[@id='kc-form-login']/@action)" - 2>/dev/null)"
+    response_from_credentials_redirected_to_next_auth="$(cookiecurl $api/credential)"
+
+    ### login flow - RADON auth ###
+        redirect_url_to_radonauth="$(echo $response_from_credentials_redirected_to_next_auth | xmllint --html --xpath "string(//a[@id='zocial-keycloak-xlab-oidc-provider-to-keycloak-radon']/@href)" - 2>/dev/null)"
+        response_radonauth="$(cookiecurl ${auth_base_url}${redirect_url_to_radonauth})"
+
+        login_url_radonauth="$(echo $response_radonauth | xmllint --html --xpath "string(//form[@id='kc-form-login']/@action)" - 2>/dev/null)"
+        cookiecurl "$login_url_radonauth" -d "username=$your_username" -d "password=$your_password" -d credentialId=""
+        redirect_url="$redirect_url_radonauth"
+    ### end RADON auth login flow ###
+
+    ### login flow - internal auth ###
+        redirect_url_internal="$(echo $response_from_credentials_redirected_to_next_auth | xmllint --html --xpath "string(//form[@id='kc-form-login']/@action)" - 2>/dev/null)"
+        redirect_url="$redirect_url_internal"
+    ### end internal auth login flow ###
+
+    # final login step, sets cookies and automatically completes the /credential request
     cookiecurl "$redirect_url" -d "username=$your_username" -d "password=$your_password" -d credentialId=""
 
     # normal usage


### PR DESCRIPTION
This adds docs on how to log in with RADON credentials, alongside the instructions for internal auth.

Closes #148.