### PR TITLE
Make maxsize property optional for TOSCA ObjectStorage normative type

### DIFF
--- a/src/opera/stdlib/v_1_3.yaml
+++ b/src/opera/stdlib/v_1_3.yaml
@@ -529,6 +529,8 @@ node_types:
     properties:
       maxsize:
         type: scalar-unit.size
+        # This differs from the definition in section 5.9.10 of the TOSCA standard
+        required: false
         constraints:
           - greater_or_equal: 0 GB
     capabilities:


### PR DESCRIPTION
In #166 we found that `tosca.nodes.Storage.ObjectStorage` TOSCA 
normative type has a maxsize property which is described to be optional 
but its type definition doesn't explicitly set required keyname to false, 
so we had to do it in order to prevent that opera would treat it as a 
required TOSCA property which would be against the standard.

Must be merged after #165.
Fixes #166.