### PR TITLE
CLI updates: help messages, resolving issues, tab completion update etc.

### DIFF
--- a/src/opera/commands/deploy.py
+++ b/src/opera/commands/deploy.py
@@ -19,11 +19,11 @@ from opera.utils import prompt_yes_no_question
 def add_parser(subparsers):
     parser = subparsers.add_parser(
         "deploy",
-        help="Deploy service template from CSAR"
+        help="Deploy TOSCA service template or CSAR"
     )
     parser.add_argument(
         "--instance-path", "-p",
-        help=".opera storage folder location"
+        help="Storage folder location (instead of default .opera)"
     )
     parser.add_argument(
         "--inputs", "-i", type=argparse.FileType("r"),
@@ -54,7 +54,7 @@ def add_parser(subparsers):
     )
     parser.add_argument(
         "template", type=argparse.FileType("r"), nargs="?",
-        help="TOSCA YAML service template file",
+        help="TOSCA YAML service template file or CSAR",
     ).complete = shtab.FILE
     parser.set_defaults(func=_parser_callback)
 

--- a/src/opera/commands/diff.py
+++ b/src/opera/commands/diff.py
@@ -4,8 +4,8 @@ import typing
 from os import path
 from pathlib import Path, PurePath
 
+import shtab
 import yaml
-from yaml import YAMLError
 
 from opera.compare.instance_comparer import InstanceComparer
 from opera.compare.template_comparer import TemplateComparer, TemplateContext
@@ -23,11 +23,11 @@ def add_parser(subparsers):
     parser.add_argument(
         "--instance-path", "-p",
         help=".opera storage folder location"
-    )
+    ).complete = shtab.DIR
     parser.add_argument(
         "--inputs", "-i", type=argparse.FileType("r"),
         help="Optional: YAML or JSON file with inputs that will be used along with the comparison",
-    )
+    ).complete = shtab.FILE
     parser.add_argument(
         "--verbose", "-v", action="store_true",
         help="Turns on verbose mode",
@@ -47,7 +47,7 @@ def add_parser(subparsers):
     parser.add_argument(
         "template", type=argparse.FileType("r"), nargs="?",
         help="TOSCA YAML service template file",
-    )
+    ).complete = shtab.FILE
     parser.set_defaults(func=_parser_callback)
 
 
@@ -80,7 +80,7 @@ def _parser_callback(args):
             inputs_new = yaml.safe_load(args.inputs)
         else:
             inputs_new = {}
-    except YAMLError as e:
+    except yaml.YAMLError as e:
         print("Invalid inputs: {}".format(e))
         return 1
 

--- a/src/opera/commands/diff.py
+++ b/src/opera/commands/diff.py
@@ -22,7 +22,7 @@ def add_parser(subparsers):
     )
     parser.add_argument(
         "--instance-path", "-p",
-        help=".opera storage folder location"
+        help="Storage folder location (instead of default .opera)"
     ).complete = shtab.DIR
     parser.add_argument(
         "--inputs", "-i", type=argparse.FileType("r"),

--- a/src/opera/commands/info.py
+++ b/src/opera/commands/info.py
@@ -11,7 +11,7 @@ from opera.error import DataError, ParseError, OperaError
 from opera.parser import tosca
 from opera.parser.tosca.csar import CloudServiceArchive
 from opera.storage import Storage
-from opera.utils import format_outputs
+from opera.utils import format_outputs, save_outputs
 
 
 def add_parser(subparsers):
@@ -26,6 +26,10 @@ def add_parser(subparsers):
     parser.add_argument(
         "--format", "-f", choices=("yaml", "json"), type=str, default="yaml",
         help="Output format",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        help="Output file location"
     )
     parser.add_argument(
         "--verbose", "-v", action="store_true",
@@ -45,7 +49,10 @@ def _parser_callback(args):
     storage = Storage.create(args.instance_path)
     try:
         outs = info(args.csar_or_rootdir, storage)
-        print(format_outputs(outs, args.format))
+        if args.output:
+            save_outputs(outs, args.format, args.output)
+        else:
+            print(format_outputs(outs, args.format))
     except ParseError as e:
         print("{}: {}".format(e.loc, e))
         return 1

--- a/src/opera/commands/info.py
+++ b/src/opera/commands/info.py
@@ -21,7 +21,7 @@ def add_parser(subparsers):
     )
     parser.add_argument(
         "--instance-path", "-p",
-        help=".opera storage folder location"
+        help="Storage folder location (instead of default .opera)"
     ).complete = shtab.DIR
     parser.add_argument(
         "--format", "-f", choices=("yaml", "json"), type=str, default="yaml",
@@ -37,7 +37,7 @@ def add_parser(subparsers):
     )
     parser.add_argument(
         "csar_or_rootdir", nargs="?",
-        help="Path to a packed or unpacked CSAR. Defaults to the current directory if not specified.",
+        help="Path to a packed or unpacked TOSCA CSAR (defaults to the current directory if not specified)",
     ).complete = shtab.DIR
     parser.set_defaults(func=_parser_callback)
 

--- a/src/opera/commands/init.py
+++ b/src/opera/commands/init.py
@@ -17,11 +17,11 @@ from opera.storage import Storage
 def add_parser(subparsers):
     parser = subparsers.add_parser(
         "init",
-        help="Initialize the deployment environment for the service template or CSAR"
+        help="Initialize the deployment environment for the TOSCA service template or CSAR"
     )
     parser.add_argument(
         "--instance-path", "-p",
-        help=".opera storage folder location"
+        help="Storage folder location (instead of default .opera)"
     ).complete = shtab.DIR
     parser.add_argument(
         "--inputs", "-i", type=argparse.FileType("r"),
@@ -29,7 +29,7 @@ def add_parser(subparsers):
     ).complete = shtab.FILE
     parser.add_argument(
         "--clean", "-c", action="store_true",
-        help="Clean storage by removing previously initialized service template or CSAR",
+        help="Clean storage by removing previously initialized TOSCA service template or CSAR",
     )
     parser.add_argument(
         "--verbose", "-v", action="store_true",
@@ -37,7 +37,7 @@ def add_parser(subparsers):
     )
     parser.add_argument(
         "csar", type=argparse.FileType("r"),
-        help="Cloud service archive or service template file"
+        help="TOSCA YAML service template file or CSAR"
     ).complete = shtab.FILE
     parser.set_defaults(func=_parser_callback)
 

--- a/src/opera/commands/outputs.py
+++ b/src/opera/commands/outputs.py
@@ -8,7 +8,7 @@ import shtab
 from opera.error import DataError, ParseError
 from opera.parser import tosca
 from opera.storage import Storage
-from opera.utils import format_outputs
+from opera.utils import format_outputs, save_outputs
 
 
 def add_parser(subparsers):
@@ -25,6 +25,10 @@ def add_parser(subparsers):
         help="Output format",
     )
     parser.add_argument(
+        "--output", "-o",
+        help="Output file location"
+    )
+    parser.add_argument(
         "--verbose", "-v", action="store_true",
         help="Turns on verbose mode",
     )
@@ -39,7 +43,10 @@ def _parser_callback(args):
 
     try:
         outs = outputs(storage)
-        print(format_outputs(outs, args.format))
+        if args.output:
+            save_outputs(outs, args.format, args.output)
+        else:
+            print(format_outputs(outs, args.format))
     except ParseError as e:
         print("{}: {}".format(e.loc, e))
         return 1

--- a/src/opera/commands/outputs.py
+++ b/src/opera/commands/outputs.py
@@ -14,11 +14,11 @@ from opera.utils import format_outputs, save_outputs
 def add_parser(subparsers):
     parser = subparsers.add_parser(
         "outputs",
-        help="Retrieve service template outputs"
+        help="Retrieve deployment outputs (from TOSCA service template)"
     )
     parser.add_argument(
         "--instance-path", "-p",
-        help=".opera storage folder location"
+        help="Storage folder location (instead of default .opera)"
     ).complete = shtab.DIR
     parser.add_argument(
         "--format", "-f", choices=("yaml", "json"), type=str, default="yaml",

--- a/src/opera/commands/undeploy.py
+++ b/src/opera/commands/undeploy.py
@@ -14,11 +14,11 @@ from opera.utils import prompt_yes_no_question
 def add_parser(subparsers):
     parser = subparsers.add_parser(
         "undeploy",
-        help="Undeploy service template"
+        help="Undeploy TOSCA service template or CSAR"
     )
     parser.add_argument(
         "--instance-path", "-p",
-        help=".opera storage folder location"
+        help="Storage folder location (instead of default .opera)"
     ).complete = shtab.DIR
     parser.add_argument(
         "--workers", "-w", type=int, default=1,

--- a/src/opera/commands/update.py
+++ b/src/opera/commands/update.py
@@ -21,7 +21,7 @@ def add_parser(subparsers):
     )
     parser.add_argument(
         "--instance-path", "-p",
-        help=".opera storage folder location"
+        help="Storage folder location (instead of default .opera)"
     ).complete = shtab.DIR
     parser.add_argument(
         "--inputs", "-i", type=argparse.FileType("r"),

--- a/src/opera/commands/update.py
+++ b/src/opera/commands/update.py
@@ -2,8 +2,8 @@ import argparse
 import tempfile
 from os import path
 
+import shtab
 import yaml
-from yaml import YAMLError
 
 from opera.commands.diff import diff_instances
 from opera.compare.diff import Diff
@@ -22,11 +22,11 @@ def add_parser(subparsers):
     parser.add_argument(
         "--instance-path", "-p",
         help=".opera storage folder location"
-    )
+    ).complete = shtab.DIR
     parser.add_argument(
         "--inputs", "-i", type=argparse.FileType("r"),
         help="Optional: YAML or JSON file with inputs that will be used for deployment update",
-    )
+    ).complete = shtab.FILE
     parser.add_argument(
         "--workers", "-w", type=int, default=1,
         help="Maximum number of concurrent update threads (positive number, default 1)"
@@ -38,7 +38,7 @@ def add_parser(subparsers):
     parser.add_argument(
         "template", type=argparse.FileType("r"), nargs="?",
         help="TOSCA YAML service template file",
-    )
+    ).complete = shtab.FILE
     parser.set_defaults(func=_parser_callback)
 
 
@@ -65,7 +65,7 @@ def _parser_callback(args):
             inputs_new = yaml.safe_load(args.inputs)
         else:
             inputs_new = {}
-    except YAMLError as e:
+    except yaml.YAMLError as e:
         print("Invalid inputs: {}".format(e))
         return 1
 

--- a/src/opera/commands/validate.py
+++ b/src/opera/commands/validate.py
@@ -16,7 +16,7 @@ from opera.parser.tosca.csar import CloudServiceArchive
 def add_parser(subparsers):
     parser = subparsers.add_parser(
         "validate",
-        help="Validate service template from CSAR"
+        help="Validate TOSCA service template or CSAR"
     )
     parser.add_argument(
         "--inputs", "-i", type=argparse.FileType("r"),
@@ -28,7 +28,7 @@ def add_parser(subparsers):
     )
     parser.add_argument(
         "csar", type=argparse.FileType("r"),
-        help="Cloud service archive or service template file"
+        help="TOSCA YAML service template file or CSAR"
     ).complete = shtab.FILE
     parser.set_defaults(func=_parser_callback)
 

--- a/tests/integration/misc_tosca_types/modules/node_types/noimpl/noimpl.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/noimpl/noimpl.yaml
@@ -11,4 +11,8 @@ node_types:
       test_string:
         type: string
         required: false
+    requirements:
+      - host:
+          capability: tosca.capabilities.Compute
+          relationship: tosca.relationships.HostedOn
 ...


### PR DESCRIPTION
This PR applies some CLI updates:

- tab completion for `opera diff` and `opera update`
- save results from `opera outputs` and `opera info` to a file
- update help messages for CLI commands
- add host requirement to `noimpl` node from integration tests
- remove the duplicated archive check in `opera unpackage` command (moved to #179)

Fixes #145, closes #151.