### PR TITLE
Update tosca.nodes.Database normative type definition

### DIFF
--- a/src/opera/stdlib/v_1_3.yaml
+++ b/src/opera/stdlib/v_1_3.yaml
@@ -494,8 +494,9 @@ node_types:
         description: the logical name of the database
       port:
         type: integer
-        description: >
-          The port the underlying database service will listen to for data.
+        description: the port the underlying database service will listen to for data
+        # This differs from the definition in section 5.9.8 of the TOSCA standard
+        required: false
       user:
         type: string
         description: the optional user account name for DB administration


### PR DESCRIPTION
In #177 we found that tosca.nodes.Database TOSCA normative type has
a port property which is described to be optional but its type
definition doesn't explicitly set required keyname to false, so we had
to do it in order to prevent that opera would treat it as a required
TOSCA property which would be against the TOSCA standard.

Fixes #177.