### PR TITLE
Compatibility with PyYAML>=5.4.

### DIFF
--- a/src/opera/parser/yaml/loader.py
+++ b/src/opera/parser/yaml/loader.py
@@ -2,7 +2,12 @@ from .constructor import Constructor
 from .resolver import Resolver
 
 try:
-    from _yaml import CParser
+    try:
+        # PyYAML>=5.4
+        from yaml._yaml import CParser
+    except ModuleNotFoundError:
+        # PyYAML<5.4
+        from _yaml import CParser
 
 
     class Loader(CParser, Constructor, Resolver):  # noqa: E303
@@ -13,6 +18,7 @@ try:
 
 
 except ImportError:
+    # pylint: disable=ungrouped-imports
     from yaml.composer import Composer
     from yaml.parser import Parser
     from yaml.reader import Reader


### PR DESCRIPTION
As our YAML parser extends internal functionality, we need to be careful about our dependencies changing internally.

PyYAML moved one of our imports in 5.4 and deprecated the old path.
We now try to use the new, non-deprecated path, falling back the old path if the new one isn't available, which maintains full compatibility with all versions of our dependencies.

Closes #176.