### PR TITLE
Introduce opera notify

### DIFF
--- a/src/opera/commands/__init__.py
+++ b/src/opera/commands/__init__.py
@@ -3,6 +3,7 @@ from opera.commands import (  # noqa: F401
     diff,
     info,
     init,
+    notify,
     outputs,
     package,
     undeploy,

--- a/src/opera/commands/notify.py
+++ b/src/opera/commands/notify.py
@@ -1,0 +1,125 @@
+import argparse
+import typing
+from os import path
+from pathlib import Path, PurePath
+
+import shtab
+import yaml
+
+from opera.commands.info import info
+from opera.error import DataError, ParseError
+from opera.parser import tosca
+from opera.storage import Storage
+from opera.utils import prompt_yes_no_question
+
+
+def add_parser(subparsers):
+    parser = subparsers.add_parser(
+        "notify",
+        help="Notify the orchestrator about changes after deployment and run triggers defined in TOSCA policies"
+    )
+    parser.add_argument(
+        "--instance-path", "-p",
+        help="Storage folder location (instead of default .opera)"
+    )
+    parser.add_argument(
+        "--trigger", "-t", "--event", "-e", metavar="TRIGGER_OR_EVENT", required=True,
+        help="TOSCA policy trigger name or event that will invoke all the actions (interface operations) on policy",
+    )
+    parser.add_argument(
+        "--notification", "-n", type=argparse.FileType("r"),
+        help="Notification file (usually JSON) with changes that will be exposed to TOSCA interfaces",
+    ).complete = shtab.FILE
+    parser.add_argument(
+        "--force", "-f", action="store_true",
+        help="Skip any prompts and force execution",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="Enable verbose mode",
+    )
+    parser.set_defaults(func=_parser_callback)
+
+
+def _parser_callback(args):
+    if args.instance_path and not path.isdir(args.instance_path):
+        raise argparse.ArgumentTypeError("Directory {} is not a valid path!".format(args.instance_path))
+
+    storage = Storage.create(args.instance_path)
+    status = info(None, storage)["status"]
+
+    if not args.force and storage.exists("instances"):
+        if status == "initialized":
+            print("Running notify without previously running deploy might have unexpected consequences.")
+            question = prompt_yes_no_question()
+            if not question:
+                return 0
+        if status == "interrupted":
+            print("Running notify after an interrupted deployment might have unexpected consequences.")
+            question = prompt_yes_no_question()
+            if not question:
+                return 0
+        if status == "undeployed":
+            print("Running notify in an undeployed project might have unexpected consequences.")
+            question = prompt_yes_no_question()
+            if not question:
+                return 0
+
+    if not args.force and not args.trigger:
+        print("You have not specified which policy trigger to use (with --trigger/-t or --event/-e) "
+              "and in this case all the triggers will be invoked which might not be what you want.")
+        question = prompt_yes_no_question()
+        if not question:
+            return 0
+
+    # read the notification file and the pass its contents to the library function
+    notification_file_contents = Path(args.notification.name).read_text() if args.notification else None
+
+    try:
+        notify(storage, args.verbose, args.trigger, notification_file_contents)
+    except ParseError as e:
+        print("{}: {}".format(e.loc, e))
+        return 1
+    except DataError as e:
+        print(str(e))
+        return 1
+
+    return 0
+
+
+def notify(storage: Storage, verbose_mode: bool, trigger_name_or_event: str,
+           notification_file_contents: typing.Optional[str]):
+    if storage.exists("inputs"):
+        inputs = yaml.safe_load(storage.read("inputs"))
+    else:
+        inputs = {}
+
+    if storage.exists("root_file"):
+        service_template = storage.read("root_file")
+        workdir = str(Path.cwd())
+
+        if storage.exists("csars"):
+            csar_dir = Path(storage.path) / "csars" / "csar"
+            workdir = str(csar_dir)
+            ast = tosca.load(Path(csar_dir), PurePath(service_template).relative_to(csar_dir))
+        else:
+            ast = tosca.load(Path.cwd(), PurePath(service_template))
+
+        template = ast.get_template(inputs)
+
+        # check if specified trigger or event name exists in template
+        if trigger_name_or_event:
+            trigger_name_or_event_exists = False
+            for policy in template.policies:
+                for trigger in policy.triggers.values():
+                    if trigger_name_or_event in (trigger.name, trigger.event.data):
+                        trigger_name_or_event_exists = True
+                        break
+
+            if not trigger_name_or_event_exists:
+                raise DataError("The provided trigger or event name does not exist: {}.".format(trigger_name_or_event))
+
+        topology = template.instantiate(storage)
+        topology.notify(verbose_mode, workdir, trigger_name_or_event, notification_file_contents)
+    else:
+        print("There is no root_file in storage.")

--- a/src/opera/parser/tosca/v_1_3/collector_mixin.py
+++ b/src/opera/parser/tosca/v_1_3/collector_mixin.py
@@ -1,5 +1,5 @@
 # type: ignore
-from opera.constants import OperationHost
+from opera.constants import OperationHost, StandardInterfaceOperation, ConfigureInterfaceOperation
 from opera.error import DataError
 from opera.template.capability import Capability
 from opera.template.interface import Interface
@@ -146,6 +146,12 @@ class CollectorMixin:
                     timeout=timeout,
                     host=operation_host,
                 )
+
+            # unify Standard and Configure interfaces with type_uri to use only shorthand_name
+            if name == StandardInterfaceOperation.type_uri():
+                name = StandardInterfaceOperation.shorthand_name()
+            if name == ConfigureInterfaceOperation.type_uri():
+                name = ConfigureInterfaceOperation.shorthand_name()
 
             interfaces[name] = Interface(name, operations)
 

--- a/src/opera/parser/tosca/v_1_3/definition_collector_mixin.py
+++ b/src/opera/parser/tosca/v_1_3/definition_collector_mixin.py
@@ -42,12 +42,12 @@ class DefinitionCollectorMixin:
                 defs[name]["inputs"].update(definition["inputs"])
                 defs[name]["operations"].update(definition["operations"])
 
-        for name, definition in self.get("interfaces", {}).items():
-            standard_interface_names = [StandardInterfaceOperation.shorthand_name(),
-                                        StandardInterfaceOperation.type_uri()]
-            configure_interface_names = [ConfigureInterfaceOperation.shorthand_name(),
-                                         ConfigureInterfaceOperation.type_uri()]
+        standard_interface_names = [StandardInterfaceOperation.shorthand_name(),
+                                    StandardInterfaceOperation.type_uri()]
+        configure_interface_names = [ConfigureInterfaceOperation.shorthand_name(),
+                                     ConfigureInterfaceOperation.type_uri()]
 
+        for name, definition in self.get("interfaces", {}).items():
             if name in standard_interface_names:
                 valid_standard_interface_operation_names = [i.value for i in StandardInterfaceOperation]
                 for operation in definition.get("operations", {}):

--- a/src/opera/template/node.py
+++ b/src/opera/template/node.py
@@ -96,11 +96,14 @@ class Node:
     def run_operation(self,
                       host: OperationHost,
                       interface: str,
-                      operation_type: Union[StandardInterfaceOperation, ConfigureInterfaceOperation],
+                      operation_type: Union[StandardInterfaceOperation, ConfigureInterfaceOperation, str],
                       instance: Base,
                       verbose: bool,
                       workdir: str):
-        operation = self.interfaces[interface].operations.get(operation_type.value)
+        if isinstance(operation_type, (StandardInterfaceOperation, ConfigureInterfaceOperation)):
+            operation = self.interfaces[interface].operations.get(operation_type.value)
+        else:
+            operation = self.interfaces[interface].operations.get(operation_type)
         if operation:
             return operation.run(host, instance, verbose, workdir)
         return True, {}, {}

--- a/tests/integration/notify/files/notification_scale_down.json
+++ b/tests/integration/notify/files/notification_scale_down.json
@@ -1,0 +1,4 @@
+{
+    "cpu_load": 7,
+    "memory_usage": 10
+}

--- a/tests/integration/notify/files/notification_scale_up.json
+++ b/tests/integration/notify/files/notification_scale_up.json
@@ -1,0 +1,4 @@
+{
+    "cpu_load": 95,
+    "memory_usage": 99
+}

--- a/tests/integration/notify/playbooks/configure.yaml
+++ b/tests/integration/notify/playbooks/configure.yaml
@@ -1,0 +1,18 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Start the configuration of monitoring
+      debug:
+        msg: "Configuring monitoring..."
+
+    - name: Print out cpu_lower_bound input
+      debug:
+        msg: "{{ cpu_lower_bound }}"
+
+    - name: Print out cpu_upper_bound input
+      debug:
+        msg: "{{ cpu_upper_bound }}"
+
+    - name: Finish the configuration of monitoring
+      debug:
+        msg: "Monitoring configured."

--- a/tests/integration/notify/playbooks/create.yaml
+++ b/tests/integration/notify/playbooks/create.yaml
@@ -1,0 +1,10 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Start creating AWS Lambda
+      debug:
+        msg: "Creating AWS Lambda..."
+
+    - name: Finish creating AWS Lambda
+      debug:
+        msg: "Created AWS Lambda."

--- a/tests/integration/notify/playbooks/delete.yaml
+++ b/tests/integration/notify/playbooks/delete.yaml
@@ -1,0 +1,10 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Start deleting AWS Lambda
+      debug:
+        msg: "Deleting AWS Lambda..."
+
+    - name: Finish deleting AWS Lambda
+      debug:
+        msg: "Deleted AWS Lambda."

--- a/tests/integration/notify/playbooks/scale_down.yaml
+++ b/tests/integration/notify/playbooks/scale_down.yaml
@@ -1,0 +1,14 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Start scaling down
+      debug:
+        msg: "Scaling down..."
+
+    - name: See what's in the notification file from monitoring that was supplied to opera notify
+      debug:
+        msg: "{{ notification }}"
+
+    - name: Finish scaling down
+      debug:
+        msg: "Scaled down..."

--- a/tests/integration/notify/playbooks/scale_up.yaml
+++ b/tests/integration/notify/playbooks/scale_up.yaml
@@ -1,0 +1,14 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Start scaling up
+      debug:
+        msg: "Scaling up..."
+
+    - name: See what's in the notification file from monitoring that was supplied to opera notify
+      debug:
+        msg: "{{ notification }}"
+
+    - name: Finish scaling up
+      debug:
+        msg: "Scaled up..."

--- a/tests/integration/notify/runme.sh
+++ b/tests/integration/notify/runme.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# get opera executable
+opera_executable="$1"
+
+# perform integration test
+$opera_executable validate service.yaml
+$opera_executable deploy service.yaml
+# scale down by calling scale_down_trigger with notification_scale_down.json notification file
+$opera_executable notify -e scale_down_trigger -n files/notification_scale_down.json
+# scale up by calling scale_up_trigger with notification_scale_up.json notification file
+$opera_executable notify -e scale_up_trigger -n files/notification_scale_up.json
+$opera_executable undeploy

--- a/tests/integration/notify/service.yaml
+++ b/tests/integration/notify/service.yaml
@@ -1,0 +1,84 @@
+tosca_definitions_version: tosca_simple_yaml_1_3
+
+node_types:
+  radon.nodes.aws.AwsLambda:
+    derived_from: tosca.nodes.SoftwareComponent
+    interfaces:
+      tosca.interfaces.node.lifecycle.Standard:
+        operations:
+          create: playbooks/create.yaml
+          delete: playbooks/delete.yaml
+      radon.interfaces.scaling:
+        operations:
+          scale_down: playbooks/scale_down.yaml
+          scale_up: playbooks/scale_up.yaml
+
+  radon.nodes.monitoring.configure:
+    derived_from: tosca.nodes.SoftwareComponent
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        operations:
+          configure:
+            implementation: playbooks/configure.yaml
+            inputs:
+              cpu_lower_bound:
+                type: float
+                default: { get_property: [ radon.policies.scaling.ScaleDown, cpu_lower_bound ] }
+              cpu_upper_bound:
+                type: float
+                default: { get_property: [ radon.policies.scaling.ScaleUp, cpu_upper_bound ] }
+
+policy_types:
+  radon.policies.scaling.ScaleDown:
+    derived_from: tosca.policies.Scaling
+    properties:
+      cpu_lower_bound:
+        description: The lower bound for the CPU
+        type: float
+        required: false
+    targets: [ radon.nodes.aws.AwsLambda, radon.nodes.monitoring.configure ]
+    triggers:
+      radon.triggers.scaling.ScaleDown:
+        description: A trigger for scaling down
+        event: scale_down_trigger
+        target_filter:
+          node: radon.nodes.aws.AwsLambda
+        action:
+          - call_operation: radon.interfaces.scaling.scale_down
+
+  radon.policies.scaling.ScaleUp:
+    derived_from: tosca.policies.Scaling
+    properties:
+      cpu_upper_bound:
+        description: The upper bound for the CPU
+        type: float
+        required: false
+    targets: [ radon.nodes.aws.AwsLambda, radon.nodes.monitoring.configure ]
+    triggers:
+      radon.triggers.scaling.ScaleUp:
+        description: A trigger for scaling up
+        event: scale_up_trigger
+        target_filter:
+          node: radon.nodes.aws.AwsLambda
+        action:
+          - call_operation: radon.interfaces.scaling.scale_up
+
+topology_template:
+  node_templates:
+    aws_lambda:
+      type: radon.nodes.aws.AwsLambda
+
+    configure_monitoring:
+      type: radon.nodes.monitoring.configure
+
+  policies:
+    - scale_down:
+        type: radon.policies.scaling.ScaleDown
+        properties:
+          cpu_lower_bound: 10
+
+    - scale_up:
+        type: radon.policies.scaling.ScaleUp
+        properties:
+          cpu_upper_bound: 90


### PR DESCRIPTION
With this PR we will supply new opera CLI command called `opera notify`, which will bring the option to inform the orchestrator about the changes after the deployment and to execute various policy trigger actions (Ansible playbooks). This command will also make possible to implement scaling actions with xOpera. (see #108).

This PR has to be merged after #187. 

Closes #32.