### PR TITLE
Fix for diff_instances for different workdirs

### DIFF
--- a/src/opera/commands/diff.py
+++ b/src/opera/commands/diff.py
@@ -163,8 +163,8 @@ def diff_instances(
         instance_comparer: InstanceComparer,
         verbose_mode: bool
 ):
-    template_old = get_template(storage_old)
-    template_new = get_template(storage_new)
+    template_old = get_template(storage_old, workdir_old)
+    template_new = get_template(storage_new, workdir_new)
     topology_old = template_old.instantiate(storage_old)
     topology_new = template_new.instantiate(storage_new)
 

--- a/src/opera/commands/update.py
+++ b/src/opera/commands/update.py
@@ -116,8 +116,8 @@ def update(
         overwrite: bool
 ):
 
-    template_old = get_template(storage_old)
-    template_new = get_template(storage_new)
+    template_old = get_template(storage_old, workdir_old)
+    template_new = get_template(storage_new, workdir_new)
     topology_old = template_old.instantiate(storage_old)
     topology_new = template_new.instantiate(storage_new)
 

--- a/src/opera/utils.py
+++ b/src/opera/utils.py
@@ -86,7 +86,7 @@ def get_workdir(storage):
         return str(Path.cwd())
 
 
-def get_template(storage):
+def get_template(storage, workdir):
     if storage.exists("inputs"):
         inputs = storage.read_json("inputs")
     else:
@@ -99,7 +99,7 @@ def get_template(storage):
             csar_dir = Path(storage.path) / "csars" / "csar"
             ast = tosca.load(Path(csar_dir), PurePath(service_template).relative_to(csar_dir))
         else:
-            ast = tosca.load(Path.cwd(), PurePath(service_template))
+            ast = tosca.load(Path(workdir), PurePath(service_template))
 
         template = ast.get_template(inputs)
         return template

--- a/tests/unit/opera/compare/conftest.py
+++ b/tests/unit/opera/compare/conftest.py
@@ -106,7 +106,7 @@ def prepare_template(path, yaml_text, template):
     ast = tosca.load(path, name)
     template = ast.get_template({})
     topology = template.instantiate(storage)
-    return template, topology, path
+    return template, topology, path, storage
 
 
 @pytest.fixture

--- a/tests/unit/opera/compare/test_workdir.py
+++ b/tests/unit/opera/compare/test_workdir.py
@@ -1,0 +1,21 @@
+from opera.commands.diff import diff_instances
+from opera.compare.instance_comparer import InstanceComparer
+from opera.compare.template_comparer import TemplateComparer
+
+
+class TestWorkirCompare:
+    def test_instance_diff(self, service_template1, service_template2):
+        storage_1 = service_template1[3]
+        storage_2 = service_template2[3]
+        comparer_template = TemplateComparer()
+        comparer_instance = InstanceComparer()
+
+        diff = diff_instances(storage_1, service_template1[2],
+                              storage_2, service_template2[2],
+                              comparer_template, comparer_instance,
+                              False)
+
+        assert "hello-1" in diff.changed["nodes"].changed
+        assert "hello-2" in diff.changed["nodes"].changed
+        assert "hello-3" in diff.changed["nodes"].changed
+        assert "hello-6" in diff.changed["nodes"].changed


### PR DESCRIPTION
get_template function in utils.py was not retrieveing template from
working directory, but rather from current directory. This commit fixes
that issue.