### PR TITLE
Fix image names for xOpera SaaS docs

### DIFF
--- a/docs/saas.rst
+++ b/docs/saas.rst
@@ -110,9 +110,9 @@ Most operations can be performed directly from an Eclipse Che/Visual Studio Code
 
 .. _xopera_saas_ide_fileselector:
 
-.. figure:: /images/xopera-saas-ide-fileselector.png
-    :target: _images/xopera-saas-ide-fileselector.png
-    :width: 95%
+.. figure:: /images/xopera-saas-che-fileselector.png
+    :target: _images/xopera-saas-che-fileselector.png
+    :width: 80%
     :align: center
 
     The file selector, activated on CSAR files.
@@ -121,9 +121,9 @@ Right clicking a CSAR brings up the option to create an xOpera SaaS project base
 
 .. _xopera_saas_ide_login:
 
-.. figure:: /images/xopera-saas-ide-login.png
-    :target: _images/xopera-saas-ide-login.png
-    :width: 95%
+.. figure:: /images/xopera-saas-che-login.png
+    :target: _images/xopera-saas-che-login.png
+    :width: 80%
     :align: center
 
     The Che plugin login dialog.
@@ -134,18 +134,18 @@ After that, you enter the name of the project, and CSAR upload and project creat
 
 .. _xopera_saas_ide_workspaces:
 
-.. figure:: /images/xopera-saas-ide-workspaces.png
-    :target: _images/xopera-saas-ide-workspaces.png
-    :width: 95%
+.. figure:: /images/xopera-saas-che-workspaces.png
+    :target: _images/xopera-saas-che-workspaces.png
+    :width: 80%
     :align: center
 
     Che plugin workspace selection.
 
 .. _xopera_saas_ide_project:
 
-.. figure:: /images/xopera-saas-ide-project.png
-    :target: _images/xopera-saas-ide-project.png
-    :width: 95%
+.. figure:: /images/xopera-saas-che-project.png
+    :target: _images/xopera-saas-che-project.png
+    :width: 80%
     :align: center
 
     Enter your project name in this dialog.
@@ -154,9 +154,9 @@ Project creation progress is shown in the bottom right corner along with all oth
 
 .. _xopera_saas_ide_progress:
 
-.. figure:: /images/xopera-saas-ide-progress.png
-    :target: _images/xopera-saas-ide-progress.png
-    :width: 95%
+.. figure:: /images/xopera-saas-che-progress.png
+    :target: _images/xopera-saas-che-progress.png
+    :width: 80%
     :align: center
 
     The start and finish notifications for project creation.
@@ -165,9 +165,9 @@ As a final step, you can choose to deploy the project immediately, or postpone i
 
 .. _xopera_saas_ide_deployment:
 
-.. figure:: /images/xopera-saas-ide-deployment.png
-    :target: _images/xopera-saas-ide-deployment.png
-    :width: 95%
+.. figure:: /images/xopera-saas-che-deployment.png
+    :target: _images/xopera-saas-che-deployment.png
+    :width: 80%
     :align: center
 
     Choose whether or not to deploy the new project immediately.


### PR DESCRIPTION
In the previous PR (#197), we have updated the docs for our xOpera
SaaS component with numerous from Eclipse Che. We made a small mistake
because images were referenced with the wrong names in the docs and
were therefore not shown properly. This commit will fix this and will
also update the width for images within documentation, because the
images can be a little but smaller for a better view.