### PR TITLE
Update Sphinx and Read the Docs dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 bandit = "==1.7.0"
+docutils = "==0.16"
 doc8 = "==0.8.1"
 flake8 = "==3.8.4"
 flake8-import-order = "==0.18.1"
@@ -16,8 +17,8 @@ selinux = "==0.2.1"
 setuptools = "*"
 wheel = "*"
 twine = ">=3.0.0"
-sphinx = "==3.3.1"
-sphinx-rtd-theme = "==0.5.0"
+sphinx = "==3.5.3"
+sphinx-rtd-theme = "==0.5.2"
 sphinx-tabs = "==2.1.0"
 sphinx-argparse = "==0.2.5"
 sphinx-copybutton = "==0.3.1"


### PR DESCRIPTION
When pushing our docs to GitHub pages in the last days we were
surprised when some parts were not rendered correctly. We have
discovered that this has something to do with the version of Read the
Docs theme we're using, so we had to upgrade `sphinx-rtd-theme` 
package to 0.5.2 and we have also updated Sphinx to the latest 3.5.3 version.
Apart from that we also needed to set docutils to version 0.16 because doc8
always installs the latest docutils version which is now 0.17 and this one has 
an aforementioned rendering error.