### PR TITLE
CI for python 3.9 and some sanity and package updates 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,9 @@ workflows:
       - test39
       - code_coverage:
           context: opera-code-climate
+          filters:
+            branches:
+              only: master
       - pypi_test_deploy:
           requires:
             - test36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,11 @@ executors:
       - image: circleci/python:3.8.2
     environment:
       PIPENV_VENV_IN_PROJECT: true
+  python39:
+    docker:
+      - image: circleci/python:3.9.4
+    environment:
+      PIPENV_VENV_IN_PROJECT: true
 
 jobs:
   test36:
@@ -95,6 +100,10 @@ jobs:
       - run_tests
   test38:
     executor: python38
+    steps:
+      - run_tests
+  test39:
+    executor: python39
     steps:
       - run_tests
   code_coverage:
@@ -125,6 +134,7 @@ workflows:
       - test36
       - test37
       - test38
+      - test39
       - code_coverage:
           context: opera-code-climate
       - pypi_test_deploy:
@@ -132,6 +142,7 @@ workflows:
             - test36
             - test37
             - test38
+            - test39
             - code_coverage
           context: opera-test-pypi
           filters:

--- a/.sanity-config.ini
+++ b/.sanity-config.ini
@@ -196,7 +196,8 @@ disable=print-statement,
         unused-argument,
         too-few-public-methods,
         too-many-return-statements,
-        too-many-branches
+        too-many-branches,
+        duplicate-code
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/Pipfile
+++ b/Pipfile
@@ -5,12 +5,12 @@ verify_ssl = true
 
 [dev-packages]
 bandit = "==1.7.0"
-docutils = "==0.16"
-flake8 = "==3.8.4"
+docutils = "==0.17.1"
+flake8 = "==3.9.2"
 flake8-import-order = "==0.18.1"
-mypy = "==0.790"
-pydocstyle = "==5.1.1"
-pylint = "==2.6.0"
+mypy = "==0.812"
+pydocstyle = "==6.0.0"
+pylint = "==2.8.2"
 pytest = "==6.2.1"
 pytest-cov = "==2.11.1"
 selinux = "==0.2.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ url = https://github.com/xlab-si/xopera-opera
 project_urls =
     Source Code = https://github.com/xlab-si/xopera-opera
     Bug Tracker = https://github.com/xlab-si/xopera-opera/issues
+    Documentation = https://xlab-si.github.io/xopera-docs/
 author = XLAB d.o.o.
 author_email = pypi@xlab.si
 license_file = LICENSE
@@ -16,12 +17,20 @@ classifiers =
     Environment :: Console
     Intended Audience :: Developers
     Intended Audience :: System Administrators
+    Intended Audience :: Science/Research
+    Intended Audience :: Information Technology
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Topic :: Software Development
+    Topic :: Software Development :: Libraries
+    Topic :: Software Development :: Libraries :: Python Modules
+    Framework :: Ansible
 
 [options]
 package_dir =

--- a/src/opera/executor/utils.py
+++ b/src/opera/executor/utils.py
@@ -16,17 +16,14 @@ def copy(source, target):
 
 
 def write(dest_dir, content, suffix=None):
-    dest = tempfile.NamedTemporaryFile(dir=dest_dir, delete=False, suffix=suffix)
-    dest.write(content.encode("utf-8"))
-    dest.close()
-    return dest.name
+    with tempfile.NamedTemporaryFile(dir=dest_dir, delete=False, suffix=suffix) as dest:
+        dest.write(content.encode("utf-8"))
+        return dest.name
 
 
 def run_in_directory(dest_dir, cmd, env):
-    fstdout = tempfile.NamedTemporaryFile(dir=dest_dir, delete=False, suffix=".stdout")
-    fstderr = tempfile.NamedTemporaryFile(dir=dest_dir, delete=False, suffix=".stderr")
-    result = subprocess.run(cmd, cwd=dest_dir, stdout=fstdout, stderr=fstderr,  # nosec
-                            env=dict(os.environ, **env), check=False)
-    fstdout.close()
-    fstderr.close()
-    return result.returncode, fstdout.name, fstderr.name
+    with tempfile.NamedTemporaryFile(dir=dest_dir, delete=False, suffix=".stdout") as fstdout, \
+            tempfile.NamedTemporaryFile(dir=dest_dir, delete=False, suffix=".stderr") as fstderr:
+        result = subprocess.run(cmd, cwd=dest_dir, stdout=fstdout, stderr=fstderr,  # nosec
+                                env=dict(os.environ, **env), check=False)
+        return result.returncode, fstdout.name, fstderr.name

--- a/src/opera/parser/tosca/csar.py
+++ b/src/opera/parser/tosca/csar.py
@@ -256,7 +256,7 @@ class FileCloudServiceArchive(CloudServiceArchive):
         """csar_file is guaranteed to exist, be absolute, and be a file."""
         super().__init__(str(csar_file.name))
         self.csar_file = csar_file
-        self.backing_zip = ZipFile(csar_file, mode="r")
+        self.backing_zip = ZipFile(csar_file, mode="r")  # pylint: disable=consider-using-with
 
     def package_csar(self, output_file, service_template=None, csar_format="zip") -> str:
         raise NotImplementedError("Repackaging a packaged CSAR is not implemented.")
@@ -269,7 +269,7 @@ class FileCloudServiceArchive(CloudServiceArchive):
         return [PurePath(zi.filename) for zi in self.backing_zip.infolist()]
 
     def open_member(self, path: PurePath) -> IO:
-        return self.backing_zip.open(str(path), mode="r")
+        return self.backing_zip.open(str(path), mode="r")  # pylint: disable=consider-using-with
 
     def _member_exists(self, member: PurePath) -> bool:
         try:


### PR DESCRIPTION
This PR adds or changes the following things:

- CI workflow that would use Python 3.9 as the executor for sanity, unit and integration tests
- Calculate code coverage only when pushing onto master branch
- Update classifiers from setup.cfg 
- Update package versions in Pipfile
- Refactor code to satisfy pylint

Closes #150.