### PR TITLE
Updates for TOSCA requirements and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,89 @@
+# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*$py.class
 
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
 eggs/
 .eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
 *.egg-info/
+.installed.cfg
 *.egg
-dist/
+MANIFEST
 
-venv/
-.venv/
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
 .pytest_cache/
+cover/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# pyenv
+.python-version
+
+# pipenv
+Pipfile.lock
+
+# Environments
+.env
+.venv
+.venv*
+env/
+venv/
+venv*
+ENV/
+env.bak/
+venv.bak/
+
+# mypy
 .mypy_cache/
+.dmypy.json
+dmypy.json
+
+# packages
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.tar.gz
+*.zip
+*.log.*
+*.csar
+
+# default opera storage folder
+.opera

--- a/examples/policy_triggers/service.yaml
+++ b/examples/policy_triggers/service.yaml
@@ -33,6 +33,10 @@ node_types:
         type: radon.interfaces.scaling.ScaleDown
       autoscaling:
         type: radon.interfaces.scaling.AutoScale
+    requirements:
+      - host:
+          capability: tosca.capabilities.Compute
+          relationship: tosca.relationships.HostedOn
 
 interface_types:
   radon.interfaces.scaling.ScaleDown:

--- a/src/opera/parser/tosca/v_1_3/node_template.py
+++ b/src/opera/parser/tosca/v_1_3/node_template.py
@@ -86,4 +86,7 @@ class NodeTemplate(CollectorMixin, Entity):
                 )
             )
 
+        if undeclared_requirements:
+            self.abort("Undeclared requirements: {}.".format(", ".join(undeclared_requirements)), self.loc)
+
         return requirements

--- a/tests/integration/concurrency/service.yaml
+++ b/tests/integration/concurrency/service.yaml
@@ -134,7 +134,7 @@ topology_template:
         time: "1"
       requirements:
         - host: my-workstation
-        - dependency1:  hello-1
-        - dependency2:  hello-2
-        - dependency7:  hello-7
-        - dependency13:  hello-13
+        - dependency:  hello-1
+        - dependency:  hello-2
+        - dependency:  hello-7
+        - dependency:  hello-13

--- a/tests/integration/misc_tosca_types/modules/node_types/test/test.yaml
+++ b/tests/integration/misc_tosca_types/modules/node_types/test/test.yaml
@@ -40,10 +40,7 @@ node_types:
       test_capability:
         type: daily_test.capabilities.test
     requirements:
-      - host1:
+      - host:
           capability: tosca.capabilities.Compute
           relationship: daily_test.relationships.test
-      - host2:
-          capability: tosca.capabilities.Compute
-          relationship: daily_test.relationships.interfaces
 ...


### PR DESCRIPTION
This PR will:

- repair the integration test for concurrency (found in #185)
- implement catching undeclared requirements on node templates (first spotted in #63)
- update integration tests and examples according to requirement changes
- update .gitignore with more files

___________________________
Fixes #185, resolves #63, resolves #182 and resolves #186.