### PR TITLE
Refactor orchestration states for TOSCA nodes

### DIFF
--- a/src/opera/commands/deploy.py
+++ b/src/opera/commands/deploy.py
@@ -59,7 +59,7 @@ def add_parser(subparsers):
     parser.set_defaults(func=_parser_callback)
 
 
-def _parser_callback(args):
+def _parser_callback(args):  # pylint: disable=too-many-statements
     if args.instance_path and not path.isdir(args.instance_path):
         raise argparse.ArgumentTypeError("Directory {} is not a valid path!".format(args.instance_path))
 
@@ -72,7 +72,7 @@ def _parser_callback(args):
     delete_existing_state = False
 
     if storage.exists("instances"):
-        if args.resume and status == "interrupted":
+        if args.resume and status == "error":
             if not args.force:
                 print("The resume deploy option might have unexpected consequences on the already deployed blueprint.")
                 question = prompt_yes_no_question()
@@ -89,10 +89,16 @@ def _parser_callback(args):
                     delete_existing_state = True
                 else:
                     return 0
+        elif status == "initialized":
+            print("The project is initialized. You have to deploy it first to be able to run undeploy.")
+            return 0
+        elif status == "undeploying":
+            print("The project is currently undeploying. Please try again after the undeployment.")
+            return 0
         elif status == "deployed":
             print("All instances have already been deployed.")
             return 0
-        elif status == "interrupted":
+        elif status == "error":
             print("The instance model already exists. Use --resume/-r to continue or --clean-state/-c to delete "
                   "current deployment state and start over the deployment.")
             return 0

--- a/src/opera/commands/info.py
+++ b/src/opera/commands/info.py
@@ -123,7 +123,7 @@ def info(csar_or_rootdir: Optional[PurePath], storage: Storage) -> dict:
             # We need to instantiate the template in order
             # to get access to the instance state.
             topology = template.instantiate(storage)
-            info_dict["status"] = topology.get_info()
+            info_dict["status"] = topology.status()
         else:
             info_dict["status"] = "initialized"
 

--- a/src/opera/commands/notify.py
+++ b/src/opera/commands/notify.py
@@ -54,13 +54,16 @@ def _parser_callback(args):
             question = prompt_yes_no_question()
             if not question:
                 return 0
-        if status == "interrupted":
-            print("Running notify after an interrupted deployment might have unexpected consequences.")
+        elif status in ("deploying", "undeploying"):
+            print("The project is in the middle of some other operation. Please try again after some time.")
+            return 0
+        elif status == "undeployed":
+            print("Running notify in an undeployed project might have unexpected consequences.")
             question = prompt_yes_no_question()
             if not question:
                 return 0
-        if status == "undeployed":
-            print("Running notify in an undeployed project might have unexpected consequences.")
+        elif status == "error":
+            print("Running notify after a deployment with an error might have unexpected consequences.")
             question = prompt_yes_no_question()
             if not question:
                 return 0

--- a/src/opera/commands/undeploy.py
+++ b/src/opera/commands/undeploy.py
@@ -51,18 +51,24 @@ def _parser_callback(args):
     status = info(None, storage)["status"]
 
     if storage.exists("instances"):
-        if args.resume and status == "interrupted":
+        if args.resume and status == "error":
             if not args.force:
                 print("The resume undeploy option might have unexpected consequences on the already "
                       "undeployed blueprint.")
                 question = prompt_yes_no_question()
                 if not question:
                     return 0
-        elif status == "interrupted":
-            print("The instance model already exists. Use --resume/-r option to continue current undeployment process.")
+        elif status == "initialized":
+            print("The project is initialized. You have to deploy it first to be able to run undeploy.")
+            return 0
+        elif status == "deploying":
+            print("The project is currently deploying. Please try again after the deployment.")
             return 0
         elif status == "undeployed":
             print("All instances have already been undeployed.")
+            return 0
+        elif status == "error":
+            print("The instance model already exists. Use --resume/-r option to continue current undeployment process.")
             return 0
 
     try:

--- a/src/opera/instance/base.py
+++ b/src/opera/instance/base.py
@@ -76,10 +76,11 @@ class Base:
                       operation_type: Union[StandardInterfaceOperation, ConfigureInterfaceOperation],
                       verbose: bool,
                       workdir: str):
-        success, outputs, attributes = \
-            self.template.run_operation(host, interface, operation_type, self, verbose, workdir)
+        success, outputs, attributes = self.template.run_operation(host, interface, operation_type, self, verbose,
+                                                                   workdir)
 
         if not success:
+            self.set_state(NodeState.ERROR)
             raise OperationError("Failed")
 
         for params, value in outputs:

--- a/src/opera/instance/node.py
+++ b/src/opera/instance/node.py
@@ -9,7 +9,7 @@ from opera.value import Value
 from .base import Base
 
 
-class Node(Base):
+class Node(Base):  # pylint: disable=too-many-public-methods
     def __init__(self, template, instance_id):
         super().__init__(template, instance_id)
 
@@ -37,12 +37,24 @@ class Node(Base):
                     rel.read()
 
     @property
+    def deploying(self):
+        return self.state in (NodeState.CREATING, NodeState.CREATED, NodeState.CONFIGURING, NodeState.STARTING)
+
+    @property
     def deployed(self):
         return self.state == NodeState.STARTED
 
     @property
+    def undeploying(self):
+        return self.state in (NodeState.STOPPING, NodeState.DELETING)
+
+    @property
     def undeployed(self):
         return self.state == NodeState.INITIAL
+
+    @property
+    def error(self):
+        return self.state == NodeState.ERROR
 
     @property
     def ready_for_deploy(self):

--- a/src/opera/instance/topology.py
+++ b/src/opera/instance/topology.py
@@ -13,14 +13,23 @@ class Topology:
             node.instantiate_relationships()
             node.read()
 
-    def get_info(self):
-        if all(node.undeployed for node in self.nodes.values()):
-            return "undeployed"
+    def status(self):
+        if any(node.deploying for node in self.nodes.values()):
+            return "deploying"
 
         if all(node.deployed for node in self.nodes.values()):
             return "deployed"
 
-        return "interrupted"
+        if any(node.undeploying for node in self.nodes.values()):
+            return "undeploying"
+
+        if all(node.undeployed for node in self.nodes.values()):
+            return "undeployed"
+
+        if any(node.error for node in self.nodes.values()):
+            return "error"
+
+        return "unknown"
 
     def deploy(self, verbose, workdir, num_workers=None):
         # Currently, we are running a really stupid O(n^3) algorithm, but unless we get to the templates with

--- a/tests/integration/cli_commands/runme.sh
+++ b/tests/integration/cli_commands/runme.sh
@@ -82,7 +82,7 @@ sleep 2s && kill -SIGKILL $DEPLOY_TIMEOUT_PID
 
 # test opera info status after deploy
 info_out="$($opera_executable info --format json)"
-test "$(echo "$info_out" | jq -r .status)" = "interrupted"
+test "$(echo "$info_out" | jq -r .status)" = "deploying"
 
 # resume service template deploy (with force option to skip prompts)
 $opera_executable deploy --resume --force
@@ -193,7 +193,7 @@ sleep 2s && kill -SIGKILL $UNDEPLOY_TIMEOUT_PID
 
 # test opera info status after undeploy
 info_out="$($opera_executable info -p ./csar-test-dir -f json)"
-test "$(echo "$info_out" | jq -r .status)" = "interrupted"
+test "$(echo "$info_out" | jq -r .status)" = "undeploying"
 
 # resume service template undeploy (with force option to skip prompts)
 $opera_executable undeploy -p ./csar-test-dir -r -f


### PR DESCRIPTION
In #203 we found out that orchestration state/status which is returned
by opera info could be improved. This has been done now and xOpera now
provides the following orchestration states (the are also CLI commands
that trigger changing the state in the brackets):

- `initialized` (opera init)
- `deploying` (opera deploy)
- `deployed` (opera deploy)
- `undeploying` (opera undeploy)
- `undeployed` (opera undeploy)
- `error` (opera deploy/undeploy/update/notify)
- `unknown` (for special cases which might happen)

These state are changed during the execution of TOSCA interface
operations (e.g. Ansible playbooks). We had to modify our CLI commands
a little and also our integration tests.