### PR TITLE
Fix parsing for interfaces and some other minor updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,11 +68,6 @@ commands:
       - run: git push origin stable
 
 executors:
-  python37:
-    docker:
-      - image: circleci/python:3.7.4
-    environment:
-      PIPENV_VENV_IN_PROJECT: true
   python38:
     docker:
       - image: circleci/python:3.8.2
@@ -90,10 +85,6 @@ executors:
       PIPENV_VENV_IN_PROJECT: true
 
 jobs:
-  test37:
-    executor: python37
-    steps:
-      - run_tests
   test38:
     executor: python38
     steps:
@@ -131,7 +122,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - test37
       - test38
       - test39
       - test310
@@ -142,7 +132,6 @@ workflows:
               only: master
       - pypi_test_deploy:
           requires:
-            - test37
             - test38
             - test39
             - test310

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ classifiers =
     Operating System :: POSIX
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10

--- a/src/opera/compare/template_comparer.py
+++ b/src/opera/compare/template_comparer.py
@@ -116,11 +116,15 @@ class TemplateComparer:
 
     @staticmethod
     def _compare_file(filepath1, filepath2, context):
-        equal = filecmp.cmp(
-            path.join(context.workdir1, filepath1),
-            path.join(context.workdir2, filepath2),
-            shallow=False
-        )
+        equal = False
+        if filepath1 and filepath2:
+            equal = filecmp.cmp(
+                path.join(context.workdir1, filepath1),
+                path.join(context.workdir2, filepath2),
+                shallow=False
+            )
+        elif not filepath1 and not filepath2:
+            equal = True
         return equal, f"file {filepath1}"
 
     @staticmethod

--- a/src/opera/instance/base.py
+++ b/src/opera/instance/base.py
@@ -94,7 +94,7 @@ class Base:
             self.set_attribute(name, value)
 
     def set_attribute(self, name, value):
-        # TODO(@tadeboro): Add type validation.
+        # TODO: Add type validation.
         if name not in self.attributes:
             raise DataError(
                 f"Instance has no '{name}' attribute. Available attributes: {', '.join(self.attributes.keys())}"

--- a/src/opera/instance/node.py
+++ b/src/opera/instance/node.py
@@ -148,7 +148,7 @@ class Node(Base):  # pylint: disable=too-many-public-methods
                            StandardInterfaceOperation.START, verbose, workdir)
         self.set_state(NodeState.STARTED)
 
-        # TODO(@tadeboro): Execute various add hooks
+        # TODO: Execute various add hooks
         thread_utils.print_thread(f"  Deployment of {self.tosca_id} complete")
 
     def undeploy(self, verbose, workdir):
@@ -164,7 +164,7 @@ class Node(Base):  # pylint: disable=too-many-public-methods
                            StandardInterfaceOperation.DELETE, verbose, workdir)
         self.set_state(NodeState.INITIAL)
 
-        # TODO(@tadeboro): Execute various remove hooks
+        # TODO: Execute various remove hooks
 
         self.reset_attributes()
         self.write()

--- a/src/opera/parser/tosca/v_1_3/artifact_definition.py
+++ b/src/opera/parser/tosca/v_1_3/artifact_definition.py
@@ -43,5 +43,5 @@ class ArtifactDefinition(Entity):
         return Value(typ, False)
 
     def get_value_type(self, service_ast):  # pylint: disable=no-self-use
-        # TODO(@tadeboro): Implement types later.
+        # TODO: Implement types later.
         return None

--- a/src/opera/parser/tosca/v_1_3/attribute_definition.py
+++ b/src/opera/parser/tosca/v_1_3/attribute_definition.py
@@ -24,5 +24,5 @@ class AttributeDefinition(Entity):
         return Value(typ, False)
 
     def get_value_type(self, service_ast):  # pylint: disable=no-self-use
-        # TODO(@tadeboro): Implement type checks later.
+        # TODO: Implement type checks later.
         return None

--- a/src/opera/parser/tosca/v_1_3/collector_mixin.py
+++ b/src/opera/parser/tosca/v_1_3/collector_mixin.py
@@ -72,11 +72,12 @@ class CollectorMixin:
             assigned_operations = assignment.get("operations", {})
             undeclared_operations = set(assigned_operations.keys()) - defined_operations.keys()
             if undeclared_operations:
+                typ.check_tosca_standard_and_configure_interfaces(name, undeclared_operations)
                 self.abort(f"Undeclared operations: {', '.join(undeclared_operations)}.", self.loc)
 
             operations = {}
             for op_name, op_definition in defined_operations.items():
-                op_assignment = assigned_operations.get(name, {})
+                op_assignment = assigned_operations.get(op_name, {})
                 undeclared_inputs = set()
 
                 # Inputs come from four different sources:

--- a/src/opera/parser/tosca/v_1_3/parameter_definition.py
+++ b/src/opera/parser/tosca/v_1_3/parameter_definition.py
@@ -11,7 +11,7 @@ from ..string import String
 from ..void import Void
 
 
-# TODO(@tadeboro): Unify ParameterDefinition and PropertyDefinition and add
+# TODO: Unify ParameterDefinition and PropertyDefinition and add
 # runtime checks. Refinement will be a PITA ...
 
 
@@ -38,5 +38,5 @@ class ParameterDefinition(Entity):
         return Value(typ, False)
 
     def get_value_type(self, service_ast):  # pylint: disable=no-self-use
-        # TODO(@tadeboro): Implement type checks.
+        # TODO: Implement type checks.
         return None

--- a/src/opera/parser/tosca/v_1_3/property_definition.py
+++ b/src/opera/parser/tosca/v_1_3/property_definition.py
@@ -34,5 +34,5 @@ class PropertyDefinition(Entity):
         return Value(typ, False)
 
     def get_value_type(self, service_ast):  # pylint: disable=no-self-use
-        # TODO(@tadeboro): Implement types later.
+        # TODO: Implement types later.
         return None

--- a/src/opera/parser/tosca/v_1_3/service_template.py
+++ b/src/opera/parser/tosca/v_1_3/service_template.py
@@ -82,7 +82,7 @@ class ServiceTemplate(Entity):
                 f"{other.tosca_definitions_version}", other.loc
             )
 
-        # TODO(@tadeboro): Should we merge the topology templates or should we
+        # TODO: Should we merge the topology templates or should we
         # be doing substitution mapping instead?
         for key in (
                 "repositories",

--- a/src/opera/parser/tosca/v_1_3/topology_template.py
+++ b/src/opera/parser/tosca/v_1_3/topology_template.py
@@ -20,7 +20,7 @@ class TopologyTemplate(Entity):
         groups=Map(GroupDefinition),
         policies=List(Map(PolicyDefinition)),
         outputs=Map(ParameterDefinition),
-        # TODO(@tadeboro): substitution_mappings and workflows
+        # TODO: substitution_mappings and workflows
     )
 
     def get_template(self, inputs, service_ast):

--- a/src/opera/template/node.py
+++ b/src/opera/template/node.py
@@ -59,7 +59,7 @@ class Node:
         return typ in self.types
 
     def instantiate(self):
-        # NOTE(@tadeboro): This is where we should handle multiple instances.
+        # NOTE: This is where we should handle multiple instances.
         # At the moment, we simply create one instance per node template. But
         # the algorithm is fully prepared for multiple instances.
         node_id = self.name + "_0"
@@ -67,7 +67,7 @@ class Node:
         return self.instances.values()
 
     def get_host(self):
-        # TODO(@tadeboro): Properly handle situations where multiple hosts are
+        # TODO: Properly handle situations where multiple hosts are
         # available.
 
         # 1. Scan requirements for direct compute host and return one.

--- a/src/opera/template/operation.py
+++ b/src/opera/template/operation.py
@@ -16,12 +16,9 @@ class Operation:
         self.host = host
 
     def run(self, host: OperationHost, instance, verbose, workdir, validate):
-        thread_utils.print_thread(f"    Executing {self.name} on {instance.tosca_id}")
-
         # TODO(@tadeboro): Respect the timeout option.
         # TODO(@tadeboro): Add host validation.
-        # TODO(@tadeboro): Properly handle SELF - not even sure what this
-        # proper way would be at this time.
+        # TODO(@tadeboro): Properly handle SELF - not even sure what this proper way would be at this time.
         host = self.host or host
         if host in (OperationHost.SELF, OperationHost.HOST):
             actual_host = instance.get_host()
@@ -37,6 +34,9 @@ class Operation:
         # TODO: Currently when primary is None we skip running the operation. Fix this if needed.
         if not self.primary:
             return True, {}, {}
+
+        # TODO: We print output only when primary is defined so we can run something. Fix this if needed.
+        thread_utils.print_thread(f"    Executing {self.name} on {instance.tosca_id}")
 
         # TODO(@tadeboro): Generalize executors.
         success, ansible_outputs = ansible.run(

--- a/src/opera/template/operation.py
+++ b/src/opera/template/operation.py
@@ -16,9 +16,9 @@ class Operation:
         self.host = host
 
     def run(self, host: OperationHost, instance, verbose, workdir, validate):
-        # TODO(@tadeboro): Respect the timeout option.
-        # TODO(@tadeboro): Add host validation.
-        # TODO(@tadeboro): Properly handle SELF - not even sure what this proper way would be at this time.
+        # TODO: Respect the timeout option.
+        # TODO: Add host validation.
+        # TODO: Properly handle SELF - not even sure what this proper way would be at this time.
         host = self.host or host
         if host in (OperationHost.SELF, OperationHost.HOST):
             actual_host = instance.get_host()
@@ -38,7 +38,7 @@ class Operation:
         # TODO: We print output only when primary is defined so we can run something. Fix this if needed.
         thread_utils.print_thread(f"    Executing {self.name} on {instance.tosca_id}")
 
-        # TODO(@tadeboro): Generalize executors.
+        # TODO: Generalize executors.
         success, ansible_outputs = ansible.run(
             actual_host, str(self.primary),
             tuple(str(i) for i in self.dependencies),

--- a/src/opera/template/topology.py
+++ b/src/opera/template/topology.py
@@ -88,7 +88,7 @@ class Topology:
     # TOSCA functions
     #
     def get_input(self, params):
-        # TODO(@tadeboro): Allow nested data access.
+        # TODO: Allow nested data access.
         if not isinstance(params, list):
             params = [params]
 

--- a/tests/unit/opera/parser/tosca/test_void.py
+++ b/tests/unit/opera/parser/tosca/test_void.py
@@ -1,13 +1,13 @@
 class TestBuild:
-    # TODO(@tadeboro): Add tests.
+    # TODO: Add tests.
     pass
 
 
 class TestInit:
-    # TODO(@tadeboro): Add tests.
+    # TODO: Add tests.
     pass
 
 
 class TestGetValue:
-    # TODO(@tadeboro): Add tests.
+    # TODO: Add tests.
     pass

--- a/tests/unit/opera/parser/yaml/test_loader.py
+++ b/tests/unit/opera/parser/yaml/test_loader.py
@@ -46,7 +46,7 @@ VALID_TEST_CASES = [
              """),
         {"d": ["with", "strs", {"dct": 1, "of": 2, "nums": 3}, "list"]},
     ),
-    # FIXME(@tadeboro): This fails for some reasone. Need to dig through
+    # FIXME: This fails for some reasone. Need to dig through
     # pyyaml sources and find out why null constructor is not called in this
     # case.
     #  (


### PR DESCRIPTION
This PR will:

- add fixes for TOSCA interface operations (see #237)
- add more checks for Standard and Configure TOSCA interface operations
- update outputs for execution of primary implementation artifacts
- update file comparison within template comparer
- remove CI/CD run for Python 3.7
- remove the remaining targeted TODOs

Fixes #237.